### PR TITLE
Release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "dnsglobe"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnsglobe"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal"
 keywords = ["dns", "propagation", "tui", "terminal", "networking"]


### PR DESCRIPTION
Version bump for the first release through the dist pipeline (prebuilt binaries + Homebrew formula). Tagging `v0.1.1` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)