### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "dnsglobe"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnsglobe"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal"


### PR DESCRIPTION
Version bump for the 0.2.0 release.

Since v0.1.1:
- Edition 2024, rust-version 1.85, all dependencies updated to latest (ratatui 0.30, crossterm 0.29, hickory-resolver 0.26)
- Fixed a potential panic in error-message truncation on multi-byte characters (plus a needless double allocation)
- New: Ctrl+S cycles table sorting — resolver / location / time / status / answer (stable sorts, so location doubles as group-by-location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)