### PR TITLE
Proposal: use --type optional arg flag to accept A vs CNAME vs TXT ... in the watch AND once modes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnsglobe"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ dnsglobe example.com --type TXT     # query a specific record type and watch
 dnsglobe --once example.com -t TXT  # no TUI: print results, exit (for scripts)
 ```
 
+Use `--type` (or `-t`) to choose the DNS record type. Supported types are
+`A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, and `SOA`; the default is `A`.
+
 ### Keys
 
 | Key            | Action                          |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Run:
 ```sh
 dnsglobe                            # start empty, type a domain
 dnsglobe example.com                # query immediately and watch
-dnsglobe --once example.com TXT    # no TUI: print results, exit (for scripts)
+dnsglobe example.com --type TXT     # query a specific record type and watch
+dnsglobe --once example.com -t TXT  # no TUI: print results, exit (for scripts)
 ```
 
 ### Keys

--- a/src/app.rs
+++ b/src/app.rs
@@ -125,6 +125,14 @@ impl App {
         }
     }
 
+    pub fn with_record_type(domain: String, rtype: RecordType) -> Self {
+        let rtype_idx = RECORD_TYPES.iter().position(|&t| t == rtype).unwrap_or(0);
+        Self {
+            rtype_idx,
+            ..Self::new(domain)
+        }
+    }
+
     pub fn record_type(&self) -> RecordType {
         RECORD_TYPES[self.rtype_idx]
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,31 +25,56 @@ const POLL_INTERVAL: Duration = Duration::from_secs(30);
 async fn main() -> Result<()> {
     let mut args = std::env::args().skip(1).peekable();
 
-    // `--once <domain> [type]` runs a single check and prints plain text —
+    // `--once <domain> --type <type>` runs a single check and prints plain text —
     // handy for scripts and for testing without a TTY.
     if args.peek().map(String::as_str) == Some("--once") {
         args.next();
-        let domain = args
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("usage: dnsglobe --once <domain> [type]"))?;
-        let rtype = match args.next() {
-            Some(t) => RecordType::from_str(&t.to_uppercase())
-                .map_err(|_| anyhow::anyhow!("unknown record type: {t}"))?,
-            None => RecordType::A,
-        };
+        let (domain, rtype) = parse_args(args, "dnsglobe --once <domain> [--type <type>]")?;
         return run_once(domain, rtype).await;
     }
 
-    let initial_domain = args.next().unwrap_or_default();
+    let (initial_domain, initial_rtype) = parse_args(args, "dnsglobe [domain] [--type <type>]")?;
     let terminal = ratatui::init();
-    let result = run_tui(terminal, initial_domain).await;
+    let result = run_tui(terminal, initial_domain, initial_rtype).await;
     ratatui::restore();
     result
 }
 
-async fn run_tui(mut terminal: ratatui::DefaultTerminal, initial_domain: String) -> Result<()> {
+fn parse_args(
+    args: impl IntoIterator<Item = String>,
+    usage: &'static str,
+) -> Result<(String, RecordType)> {
+    let mut domain = None;
+    let mut rtype = RecordType::A;
+    let mut iter = args.into_iter();
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--type" | "-t" => {
+                let value = iter
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("usage: {usage}"))?;
+                rtype = parse_record_type(&value)?;
+            }
+            _ if domain.is_none() => domain = Some(arg),
+            _ => return Err(anyhow::anyhow!("usage: {usage}")),
+        }
+    }
+
+    Ok((domain.unwrap_or_default(), rtype))
+}
+
+fn parse_record_type(t: &str) -> Result<RecordType> {
+    RecordType::from_str(&t.to_uppercase()).map_err(|_| anyhow::anyhow!("unknown record type: {t}"))
+}
+
+async fn run_tui(
+    mut terminal: ratatui::DefaultTerminal,
+    initial_domain: String,
+    initial_rtype: RecordType,
+) -> Result<()> {
     let auto_query = !initial_domain.is_empty();
-    let mut app = App::new(initial_domain);
+    let mut app = App::with_record_type(initial_domain, initial_rtype);
 
     // Worker tasks send results here; keeping `tx` alive in this scope means
     // `rx.recv()` never observes a closed channel.


### PR DESCRIPTION
Hi there, saw your release on X, neat tool!

I have a variety of tools internally at https://docs.ploy.ai/custom-domains where I've monitored thousands of domains go live in a matter of days, so I'm super dialed into this monitoring/observability problem right now.

I'm going to contribute this small patch to start, if you like what you see, and want more of our skills from Ploy ported over, I'll send more.

-----

AI assistant disclosures:

- I used AmpCode
- I am a novice Go programmer before AI

-----

Built locally and manually tested and verified these variations:

- `dnsglobe --once www.google.com --type A` (arg after hostname)

- `dnsglobe --once --type A www.flashtype.ai` (arg before hostname)

- `dnsglobe --type CNAME www.attention.com` (watch mode loads in the requested type first)

<img width="239" height="84" alt="image" src="https://github.com/user-attachments/assets/3ce0ad5b-6b5c-4977-90a4-7722f2863c9f" />

- `dnsglobe --type A ploy.ai` watch mode loads in requested type (works as before)

<img width="242" height="87" alt="image" src="https://github.com/user-attachments/assets/02f66fc2-52f0-4ce7-998c-cff842de56b7" />
