### PR TITLE
Add TOML config file for custom resolvers + CI for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: rustup update stable && rustup default stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Test
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: rustup update stable && rustup default stable
       - uses: Swatinem/rust-cache@v2
       - name: Format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,9 @@ dependencies = [
  "futures",
  "hickory-resolver",
  "ratatui",
+ "serde",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -868,6 +870,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1716,6 +1728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2116,45 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -2508,6 +2568,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 futures = "0.3"
 hickory-resolver = "0.26"
 ratatui = "0.30"
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
+toml = "1.1"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # dnsglobe
 
 [![crates.io](https://img.shields.io/crates/v/dnsglobe)](https://crates.io/crates/dnsglobe)
+[![dnsglobe](https://img.shields.io/aur/version/dnsglobe?label=aur%20dnsglobe)](https://aur.archlinux.org/packages/dnsglobe/)
+[![dnsglobe-bin](https://img.shields.io/aur/version/dnsglobe-bin?label=aur%20dnsglobe-bin)](https://aur.archlinux.org/packages/dnsglobe-bin/)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 **A global DNS propagation checker for your terminal** — a Rust TUI that
@@ -30,9 +32,6 @@ dot per resolver, colored by status (green agrees, magenta differs, red
 error, yellow in flight).
 
 ## Usage
-
-[![dnsglobe](https://img.shields.io/aur/version/dnsglobe?label=dnsglobe)](https://aur.archlinux.org/packages/dnsglobe/)
-[![dnsglobe-bin](https://img.shields.io/aur/version/dnsglobe-bin?label=dnsglobe-bin)](https://aur.archlinux.org/packages/dnsglobe-bin/)
 
 Install:
 
@@ -66,11 +65,39 @@ dnsglobe --once example.com TXT    # no TUI: print results, exit (for scripts)
 | Ctrl+U         | clear domain                    |
 | Esc / Ctrl+C   | quit                            |
 
+## Configuration
+
+Optionally, add your own resolvers — or replace the built-in list entirely —
+with a TOML config file at `~/.config/dnsglobe/config.toml`
+(`$XDG_CONFIG_HOME/dnsglobe/config.toml` if set). Set `DNSGLOBE_CONFIG` to
+use a different path.
+
+```toml
+# Set to true to replace the built-in list instead of extending it —
+# e.g. to watch propagation across your own nameservers only.
+replace = false
+
+[[resolvers]]
+name = "Corp DNS"        # required — shown in the Resolver column
+ip = "10.0.0.53"         # required — IPv4 or IPv6, queried on port 53
+location = "HQ"          # optional — Loc column / location sort
+lat = 40.7               # optional — position on the world map;
+lon = -74.0              #            omit both to leave it off the map
+
+[[resolvers]]
+name = "NS1 (public)"
+ip = "198.51.100.53"
+```
+
+Invalid config (bad IP, unknown key, `lat` without `lon`, `replace = true`
+with no resolvers) is reported at startup with the offending entry named.
+
 ## Notes
 
 - Several resolvers are anycast networks, so the responding node is the one
   nearest to you; the location column is the operator's home region.
-- Resolver list lives in `src/resolvers.rs` — add or remove entries freely.
-  Every entry was verified to answer external queries; many well-known ISP
-  resolvers (and, notably, all major African ones) refuse queries from
-  outside their network, so they can't be included.
+- The built-in resolver list lives in `src/resolvers.rs`; use the config file
+  above to extend or replace it without rebuilding. Every built-in entry was
+  verified to answer external queries; many well-known ISP resolvers (and,
+  notably, all major African ones) refuse queries from outside their network,
+  so they can't be included.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use hickory_resolver::proto::rr::RecordType;
 
 use crate::dns::{QueryOutcome, QueryResult};
-use crate::resolvers::RESOLVERS;
+use crate::resolvers;
 
 pub const RECORD_TYPES: &[RecordType] = &[
     RecordType::A,
@@ -113,7 +113,7 @@ impl App {
             cursor: domain.len(),
             domain,
             rtype_idx: 0,
-            rows: vec![RowState::Idle; RESOLVERS.len()],
+            rows: vec![RowState::Idle; resolvers::active().len()],
             generation: 0,
             spinner_frame: 0,
             should_quit: false,
@@ -177,7 +177,7 @@ impl App {
             return None;
         }
         self.generation += 1;
-        self.rows = vec![RowState::Pending; RESOLVERS.len()];
+        self.rows = vec![RowState::Pending; resolvers::active().len()];
         self.queried = Some((domain.clone(), self.record_type()));
         Some((domain, self.record_type(), self.generation))
     }
@@ -187,7 +187,7 @@ impl App {
     pub fn begin_requery(&mut self) -> Option<(String, RecordType, u64)> {
         let (domain, rtype) = self.queried.clone()?;
         self.generation += 1;
-        self.rows = vec![RowState::Pending; RESOLVERS.len()];
+        self.rows = vec![RowState::Pending; resolvers::active().len()];
         Some((domain, rtype, self.generation))
     }
 
@@ -210,7 +210,7 @@ impl App {
         let mut order: Vec<usize> = (0..self.rows.len()).collect();
         match self.sort {
             SortMode::Resolver => {}
-            SortMode::Location => order.sort_by_key(|&i| RESOLVERS[i].location),
+            SortMode::Location => order.sort_by_key(|&i| resolvers::active()[i].location.as_str()),
             // Fastest first; rows without a result sink to the bottom.
             SortMode::Time => order.sort_by_key(|&i| match &self.rows[i] {
                 RowState::Done { elapsed, .. } => *elapsed,
@@ -384,10 +384,10 @@ mod tests {
     #[test]
     fn full_agreement_means_agree_equals_responding() {
         // The watch-mode stop condition: agree == responding.
-        let answers = vec![&["x"] as &[&str]; crate::resolvers::RESOLVERS.len()];
+        let answers = vec![&["x"] as &[&str]; resolvers::active().len()];
         let app = app_with_answers(&answers);
         let s = app.summary();
-        assert_eq!(s.responding, crate::resolvers::RESOLVERS.len());
+        assert_eq!(s.responding, resolvers::active().len());
         assert_eq!(s.agree, s.responding);
     }
 
@@ -395,7 +395,7 @@ mod tests {
     fn unreachable_resolvers_do_not_block_full_propagation() {
         // Refused/timed-out resolvers carry no signal: with one error row,
         // the rest agreeing still counts as 100% (agree == responding).
-        let mut app = app_with_answers(&vec![&["x"] as &[&str]; RESOLVERS.len() - 1]);
+        let mut app = app_with_answers(&vec![&["x"] as &[&str]; resolvers::active().len() - 1]);
         app.rows.push(RowState::Done {
             result: QueryResult::Error("refused".into()),
             elapsed: Duration::from_secs(3),
@@ -403,23 +403,26 @@ mod tests {
         let s = app.summary();
         assert_eq!(s.groups, 1);
         assert_eq!(s.errors, 1);
-        assert_eq!(s.responding, RESOLVERS.len() - 1);
+        assert_eq!(s.responding, resolvers::active().len() - 1);
         assert_eq!(s.agree, s.responding);
     }
 
     #[test]
     fn location_sort_groups_locations_and_keeps_curated_order_within() {
-        let mut app = app_with_answers(&vec![&["x"] as &[&str]; RESOLVERS.len()]);
+        let mut app = app_with_answers(&vec![&["x"] as &[&str]; resolvers::active().len()]);
         app.sort = SortMode::Location;
         let summary = app.summary();
         let order = app.display_order(&summary);
-        let locations: Vec<&str> = order.iter().map(|&i| RESOLVERS[i].location).collect();
+        let locations: Vec<&str> = order
+            .iter()
+            .map(|&i| resolvers::active()[i].location.as_str())
+            .collect();
         assert!(locations.is_sorted());
         // Stable sort: within one location, curated order is preserved.
         let us: Vec<usize> = order
             .iter()
             .copied()
-            .filter(|&i| RESOLVERS[i].location == "US")
+            .filter(|&i| resolvers::active()[i].location == "US")
             .collect();
         assert!(us.is_sorted());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,239 @@
+//! Optional TOML config file that adds resolvers to the built-in list, or
+//! replaces the list entirely (e.g. to check propagation across your own
+//! infrastructure, or an internal split-horizon zone).
+//!
+//! Looked up at `$DNSGLOBE_CONFIG`, else `$XDG_CONFIG_HOME/dnsglobe/config.toml`,
+//! else `~/.config/dnsglobe/config.toml`. A missing default file just means
+//! the built-in list; a missing `$DNSGLOBE_CONFIG` file is an error.
+
+use std::net::IpAddr;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::resolvers::{self, Resolver};
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// When true, the config's resolvers replace the built-in list instead of
+    /// extending it.
+    #[serde(default)]
+    replace: bool,
+    #[serde(default)]
+    resolvers: Vec<Entry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Entry {
+    name: String,
+    ip: String,
+    /// Shown in the table's Loc column and used by the location sort.
+    #[serde(default)]
+    location: String,
+    /// Optional map position; give both or neither. Without them the
+    /// resolver is queried normally but not drawn on the world map.
+    lat: Option<f64>,
+    lon: Option<f64>,
+}
+
+/// Load the resolver list for this run: built-ins plus (or replaced by) the
+/// config file, if one exists.
+pub fn load() -> Result<Vec<Resolver>> {
+    let (path, required) = match std::env::var_os("DNSGLOBE_CONFIG") {
+        Some(path) => (Some(PathBuf::from(path)), true),
+        None => (default_path(), false),
+    };
+    let Some(path) = path else {
+        return Ok(resolvers::defaults());
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound && !required => {
+            return Ok(resolvers::defaults());
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("reading config file {}", path.display()));
+        }
+    };
+    let config: Config =
+        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+    resolver_list(config).with_context(|| format!("invalid config {}", path.display()))
+}
+
+fn default_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))?;
+    Some(base.join("dnsglobe").join("config.toml"))
+}
+
+/// Validate the config and merge it with the built-in list.
+fn resolver_list(config: Config) -> Result<Vec<Resolver>> {
+    let mut list = if config.replace {
+        Vec::new()
+    } else {
+        resolvers::defaults()
+    };
+    for entry in config.resolvers {
+        let ip: IpAddr = entry.ip.parse().with_context(|| {
+            format!(
+                "resolver {:?}: invalid IP address {:?}",
+                entry.name, entry.ip
+            )
+        })?;
+        let coords = match (entry.lat, entry.lon) {
+            (Some(lat), Some(lon)) => {
+                if !(-90.0..=90.0).contains(&lat) || !(-180.0..=180.0).contains(&lon) {
+                    bail!(
+                        "resolver {:?}: lat must be in -90..=90 and lon in -180..=180",
+                        entry.name
+                    );
+                }
+                Some((lat, lon))
+            }
+            (None, None) => None,
+            _ => bail!(
+                "resolver {:?}: lat and lon must be given together",
+                entry.name
+            ),
+        };
+        list.push(Resolver {
+            name: entry.name,
+            location: entry.location,
+            ip,
+            coords,
+        });
+    }
+    if list.is_empty() {
+        bail!("`replace = true` needs at least one [[resolvers]] entry");
+    }
+    Ok(list)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn list(toml_text: &str) -> Result<Vec<Resolver>> {
+        resolver_list(toml::from_str(toml_text)?)
+    }
+
+    #[test]
+    fn no_config_keeps_builtin_list() {
+        let resolvers = list("").unwrap();
+        assert_eq!(resolvers.len(), resolvers::defaults().len());
+    }
+
+    #[test]
+    fn added_resolvers_extend_the_builtin_list() {
+        let resolvers = list(
+            r#"
+            [[resolvers]]
+            name = "Corp DNS"
+            ip = "10.0.0.53"
+            location = "HQ"
+            lat = 40.7
+            lon = -74.0
+
+            [[resolvers]]
+            name = "No map"
+            ip = "2606:4700:4700::1111"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(resolvers.len(), resolvers::defaults().len() + 2);
+        let corp = &resolvers[resolvers.len() - 2];
+        assert_eq!(corp.name, "Corp DNS");
+        assert_eq!(corp.location, "HQ");
+        assert_eq!(corp.ip, "10.0.0.53".parse::<IpAddr>().unwrap());
+        assert_eq!(corp.coords, Some((40.7, -74.0)));
+        // IPv6 works; omitted location/coords stay empty/off-map.
+        let no_map = &resolvers[resolvers.len() - 1];
+        assert!(no_map.ip.is_ipv6());
+        assert_eq!(no_map.location, "");
+        assert_eq!(no_map.coords, None);
+    }
+
+    #[test]
+    fn replace_swaps_out_the_builtin_list() {
+        let resolvers = list(
+            r#"
+            replace = true
+
+            [[resolvers]]
+            name = "Only me"
+            ip = "192.0.2.1"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(resolvers.len(), 1);
+        assert_eq!(resolvers[0].name, "Only me");
+    }
+
+    #[test]
+    fn replace_with_no_resolvers_is_an_error() {
+        let err = list("replace = true").unwrap_err();
+        assert!(err.to_string().contains("at least one"));
+    }
+
+    #[test]
+    fn invalid_ip_is_an_error() {
+        let err = list(
+            r#"
+            [[resolvers]]
+            name = "Bad"
+            ip = "not-an-ip"
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("invalid IP address"));
+    }
+
+    #[test]
+    fn lat_without_lon_is_an_error() {
+        let err = list(
+            r#"
+            [[resolvers]]
+            name = "Half a coordinate"
+            ip = "192.0.2.1"
+            lat = 12.0
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("given together"));
+    }
+
+    #[test]
+    fn out_of_range_coords_are_an_error() {
+        let err = list(
+            r#"
+            [[resolvers]]
+            name = "Off the globe"
+            ip = "192.0.2.1"
+            lat = 91.0
+            lon = 0.0
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("-90..=90"));
+    }
+
+    #[test]
+    fn unknown_keys_are_rejected_to_catch_typos() {
+        assert!(toml::from_str::<Config>("replase = true").is_err());
+        assert!(
+            toml::from_str::<Config>(
+                r#"
+                [[resolvers]]
+                name = "Typo"
+                adress = "192.0.2.1"
+                "#,
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod config;
 mod dns;
 mod resolvers;
 mod ui;
@@ -15,7 +16,6 @@ use tokio::sync::mpsc;
 
 use app::App;
 use dns::QueryOutcome;
-use resolvers::RESOLVERS;
 
 /// Watch-mode re-poll interval; propagation usually moves on TTL boundaries,
 /// so sub-minute polling is plenty.
@@ -23,6 +23,10 @@ const POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Fail on a broken config before the terminal enters raw mode, so the
+    // error prints normally.
+    resolvers::init(config::load()?);
+
     let mut args = std::env::args().skip(1).peekable();
 
     // `--once <domain> [type]` runs a single check and prints plain text —
@@ -185,10 +189,10 @@ fn spawn_round(
     tx: &mpsc::UnboundedSender<QueryOutcome>,
     (domain, rtype, generation): (String, RecordType, u64),
 ) {
-    for (resolver_index, resolver) in RESOLVERS.iter().enumerate() {
+    for (resolver_index, resolver) in resolvers::active().iter().enumerate() {
         let tx = tx.clone();
         let domain = domain.clone();
-        let server: IpAddr = resolver.ip.parse().expect("resolver IPs are valid");
+        let server: IpAddr = resolver.ip;
         tokio::spawn(async move {
             let (result, elapsed) = dns::query(server, domain, rtype).await;
             let _ = tx.send(QueryOutcome {
@@ -213,9 +217,9 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("empty domain"))?;
 
     let mut tasks = tokio::task::JoinSet::new();
-    for (resolver_index, resolver) in RESOLVERS.iter().enumerate() {
+    for (resolver_index, resolver) in resolvers::active().iter().enumerate() {
         let domain = domain.clone();
-        let server: IpAddr = resolver.ip.parse().expect("resolver IPs are valid");
+        let server: IpAddr = resolver.ip;
         tasks.spawn(async move {
             let (result, elapsed) = dns::query(server, domain, rtype).await;
             QueryOutcome {
@@ -232,7 +236,7 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
 
     let summary = app.summary();
     println!("{domain} {rtype}\n");
-    for (i, (resolver, row)) in RESOLVERS.iter().zip(&app.rows).enumerate() {
+    for (i, (resolver, row)) in resolvers::active().iter().zip(&app.rows).enumerate() {
         let line = match row {
             app::RowState::Done { result, elapsed } => match result {
                 dns::QueryResult::Records { values, min_ttl } => {

--- a/src/resolvers.rs
+++ b/src/resolvers.rs
@@ -1,3 +1,54 @@
+use std::net::IpAddr;
+use std::sync::OnceLock;
+
+/// A resolver to query, either built-in or from the user's config file.
+#[derive(Debug, Clone)]
+pub struct Resolver {
+    pub name: String,
+    pub location: String,
+    pub ip: IpAddr,
+    /// (lat, lon) for the world-map view; None keeps the resolver off the map.
+    pub coords: Option<(f64, f64)>,
+}
+
+/// The resolver list for this run. Set once at startup (after the config file
+/// is applied); falls back to the built-in list so tests and library callers
+/// need no setup.
+static ACTIVE: OnceLock<Vec<Resolver>> = OnceLock::new();
+
+/// Install the resolver list for this run. Must be called before the first
+/// `active()` call and at most once.
+pub fn init(list: Vec<Resolver>) {
+    ACTIVE
+        .set(list)
+        .expect("resolver list initialized more than once");
+}
+
+pub fn active() -> &'static [Resolver] {
+    ACTIVE.get_or_init(defaults)
+}
+
+/// The built-in resolver list.
+pub fn defaults() -> Vec<Resolver> {
+    BUILTIN
+        .iter()
+        .map(|b| Resolver {
+            name: b.name.into(),
+            location: b.location.into(),
+            ip: b.ip.parse().expect("built-in resolver IPs are valid"),
+            coords: Some((b.lat, b.lon)),
+        })
+        .collect()
+}
+
+struct Builtin {
+    name: &'static str,
+    location: &'static str,
+    ip: &'static str,
+    lat: f64,
+    lon: f64,
+}
+
 /// Public DNS resolvers spread across regions. Anycast networks are marked as
 /// such — the answering node is the one nearest to you, so "location" is the
 /// operator's home region, not necessarily where the query lands. Lat/lon are
@@ -6,45 +57,37 @@
 /// Every entry has been verified to answer external queries over UDP/TCP 53.
 /// Africa currently has no reliable open Do53 resolver (large ISPs there
 /// refuse external queries); coverage comes from the anycast networks' POPs.
-pub struct Resolver {
-    pub name: &'static str,
-    pub location: &'static str,
-    pub ip: &'static str,
-    pub lat: f64,
-    pub lon: f64,
-}
-
-pub const RESOLVERS: &[Resolver] = &[
+const BUILTIN: &[Builtin] = &[
     // Global anycast
-    Resolver {
+    Builtin {
         name: "Google Public DNS",
         location: "Anycast",
         ip: "8.8.8.8",
         lat: 37.4,
         lon: -122.1,
     },
-    Resolver {
+    Builtin {
         name: "Cloudflare",
         location: "Anycast",
         ip: "1.1.1.1",
         lat: 37.8,
         lon: -122.4,
     },
-    Resolver {
+    Builtin {
         name: "Quad9",
         location: "CH/Any",
         ip: "9.9.9.9",
         lat: 47.4,
         lon: 8.5,
     },
-    Resolver {
+    Builtin {
         name: "OpenDNS (Cisco)",
         location: "US/Any",
         ip: "208.67.222.222",
         lat: 33.9,
         lon: -118.2,
     },
-    Resolver {
+    Builtin {
         name: "CleanBrowsing",
         location: "Anycast",
         ip: "185.228.168.9",
@@ -52,56 +95,56 @@ pub const RESOLVERS: &[Resolver] = &[
         lon: -112.0,
     },
     // North America
-    Resolver {
+    Builtin {
         name: "Level3",
         location: "US",
         ip: "4.2.2.2",
         lat: 39.7,
         lon: -105.0,
     },
-    Resolver {
+    Builtin {
         name: "Lumen (Qwest)",
         location: "US",
         ip: "205.171.3.66",
         lat: 40.4,
         lon: -104.0,
     },
-    Resolver {
+    Builtin {
         name: "Hurricane Electric",
         location: "US",
         ip: "74.82.42.42",
         lat: 37.6,
         lon: -122.0,
     },
-    Resolver {
+    Builtin {
         name: "Neustar UltraDNS",
         location: "US/Any",
         ip: "64.6.64.6",
         lat: 39.0,
         lon: -77.5,
     },
-    Resolver {
+    Builtin {
         name: "Comodo Secure DNS",
         location: "US",
         ip: "8.26.56.26",
         lat: 40.9,
         lon: -74.2,
     },
-    Resolver {
+    Builtin {
         name: "FortiGuard",
         location: "US/Any",
         ip: "208.91.112.53",
         lat: 37.3,
         lon: -121.9,
     },
-    Resolver {
+    Builtin {
         name: "CIRA Canadian Shield",
         location: "CA",
         ip: "149.112.121.10",
         lat: 45.4,
         lon: -75.7,
     },
-    Resolver {
+    Builtin {
         name: "ControlD",
         location: "CA/Any",
         ip: "76.76.2.0",
@@ -109,35 +152,35 @@ pub const RESOLVERS: &[Resolver] = &[
         lon: -79.4,
     },
     // Europe
-    Resolver {
+    Builtin {
         name: "DNS4EU",
         location: "EU/Any",
         ip: "86.54.11.100",
         lat: 50.1,
         lon: 14.4,
     },
-    Resolver {
+    Builtin {
         name: "CZ.NIC ODVR",
         location: "CZ",
         ip: "193.17.47.1",
         lat: 49.9,
         lon: 15.3,
     },
-    Resolver {
+    Builtin {
         name: "AdGuard DNS",
         location: "EU/Any",
         ip: "94.140.14.14",
         lat: 34.7,
         lon: 33.0,
     },
-    Resolver {
+    Builtin {
         name: "Gcore DNS",
         location: "LU/Any",
         ip: "95.85.95.85",
         lat: 49.6,
         lon: 6.1,
     },
-    Resolver {
+    Builtin {
         name: "DNS.SB",
         location: "DE/Any",
         ip: "185.222.222.222",
@@ -145,28 +188,28 @@ pub const RESOLVERS: &[Resolver] = &[
         lon: 8.7,
     },
     // Russia / Middle East
-    Resolver {
+    Builtin {
         name: "SafeDNS",
         location: "RU",
         ip: "195.46.39.39",
         lat: 55.8,
         lon: 37.6,
     },
-    Resolver {
+    Builtin {
         name: "Yandex DNS",
         location: "RU",
         ip: "77.88.8.8",
         lat: 55.6,
         lon: 37.9,
     },
-    Resolver {
+    Builtin {
         name: "Comss.one",
         location: "RU",
         ip: "83.220.169.155",
         lat: 56.3,
         lon: 38.1,
     },
-    Resolver {
+    Builtin {
         name: "Bezeq Intl",
         location: "IL",
         ip: "192.115.106.10",
@@ -174,63 +217,63 @@ pub const RESOLVERS: &[Resolver] = &[
         lon: 34.8,
     },
     // East Asia
-    Resolver {
+    Builtin {
         name: "114DNS",
         location: "CN",
         ip: "114.114.114.114",
         lat: 32.1,
         lon: 118.8,
     },
-    Resolver {
+    Builtin {
         name: "AliDNS",
         location: "CN",
         ip: "223.5.5.5",
         lat: 30.3,
         lon: 120.2,
     },
-    Resolver {
+    Builtin {
         name: "DNSPod (Tencent)",
         location: "CN",
         ip: "119.29.29.29",
         lat: 22.5,
         lon: 114.1,
     },
-    Resolver {
+    Builtin {
         name: "Baidu DNS",
         location: "CN",
         ip: "180.76.76.76",
         lat: 39.9,
         lon: 116.4,
     },
-    Resolver {
+    Builtin {
         name: "CNNIC sDNS",
         location: "CN",
         ip: "1.2.4.8",
         lat: 40.5,
         lon: 116.9,
     },
-    Resolver {
+    Builtin {
         name: "360 Secure DNS",
         location: "CN",
         ip: "101.226.4.6",
         lat: 31.2,
         lon: 121.5,
     },
-    Resolver {
+    Builtin {
         name: "KT (Kornet)",
         location: "KR",
         ip: "168.126.63.1",
         lat: 37.6,
         lon: 127.0,
     },
-    Resolver {
+    Builtin {
         name: "LG U+",
         location: "KR",
         ip: "164.124.101.2",
         lat: 36.5,
         lon: 127.9,
     },
-    Resolver {
+    Builtin {
         name: "HiNet (Chunghwa)",
         location: "TW",
         ip: "168.95.1.1",
@@ -238,21 +281,21 @@ pub const RESOLVERS: &[Resolver] = &[
         lon: 121.6,
     },
     // Southern hemisphere
-    Resolver {
+    Builtin {
         name: "Telstra",
         location: "AU",
         ip: "139.130.4.4",
         lat: -33.9,
         lon: 151.2,
     },
-    Resolver {
+    Builtin {
         name: "SafeSurfer",
         location: "NZ",
         ip: "104.197.28.121",
         lat: -36.8,
         lon: 174.8,
     },
-    Resolver {
+    Builtin {
         name: "UOL",
         location: "BR",
         ip: "200.221.11.100",
@@ -260,3 +303,17 @@ pub const RESOLVERS: &[Resolver] = &[
         lon: -46.6,
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_ips_parse_and_are_unique() {
+        let defaults = defaults(); // parses every IP; panics on a bad entry
+        let mut ips: Vec<IpAddr> = defaults.iter().map(|r| r.ip).collect();
+        ips.sort();
+        ips.dedup();
+        assert_eq!(ips.len(), defaults.len());
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::{Block, Borders, Cell, LineGauge, Paragraph, Row, Table, T
 
 use crate::app::{App, RECORD_TYPES, RowState, SPINNER, Summary};
 use crate::dns::QueryResult;
-use crate::resolvers::RESOLVERS;
+use crate::resolvers;
 
 const ACCENT: Color = Color::Cyan;
 /// Table needs ~93 cols; only show the map when there's room for both.
@@ -51,7 +51,9 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     draw_gauge(frame, app, &summary, gauge);
     // Clamp scroll so the last page stays full; height minus borders+header.
     let visible = table.height.saturating_sub(3) as usize;
-    app.scroll = app.scroll.min(RESOLVERS.len().saturating_sub(visible));
+    app.scroll = app
+        .scroll
+        .min(resolvers::active().len().saturating_sub(visible));
     draw_table(frame, app, &summary, complete, table);
     if let Some(right) = right {
         // Height follows from width via the aspect ratio; leftover space
@@ -99,7 +101,7 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_gauge(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
-    let total = RESOLVERS.len();
+    let total = resolvers::active().len();
 
     if app.queried.is_none() {
         let hint = Paragraph::new(Line::from(Span::styled(
@@ -168,7 +170,7 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
     let rows = app
         .display_order(summary)
         .into_iter()
-        .map(|i| (i, (&RESOLVERS[i], &app.rows[i])))
+        .map(|i| (i, (&resolvers::active()[i], &app.rows[i])))
         .map(|(i, (resolver, state))| {
             let (time_cell, ttl_cell, status_cell, answer_cell) = match state {
                 RowState::Idle => (
@@ -237,12 +239,15 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                 }
             };
             Row::new(vec![
-                Cell::from(resolver.name),
+                Cell::from(resolver.name.as_str()),
                 Cell::from(Span::styled(
-                    resolver.location,
+                    resolver.location.as_str(),
                     Style::new().fg(Color::DarkGray),
                 )),
-                Cell::from(Span::styled(resolver.ip, Style::new().fg(Color::DarkGray))),
+                Cell::from(Span::styled(
+                    resolver.ip.to_string(),
+                    Style::new().fg(Color::DarkGray),
+                )),
                 time_cell,
                 ttl_cell,
                 status_cell,
@@ -272,7 +277,7 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                 Line::from(format!(
                     " sort: {} (Ctrl+S) · {} resolvers (↑/↓ scroll) ",
                     app.sort.label(),
-                    RESOLVERS.len()
+                    resolvers::active().len()
                 ))
                 .right_aligned()
                 .style(Style::new().fg(Color::DarkGray)),
@@ -299,7 +304,10 @@ fn draw_map(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, are
                 color: Color::DarkGray,
                 resolution: MapResolution::High,
             });
-            for (i, (resolver, state)) in RESOLVERS.iter().zip(&app.rows).enumerate() {
+            for (i, (resolver, state)) in resolvers::active().iter().zip(&app.rows).enumerate() {
+                let Some((lat, lon)) = resolver.coords else {
+                    continue; // config resolver without map coordinates
+                };
                 let color = match state {
                     RowState::Idle => Color::DarkGray,
                     RowState::Pending => Color::Yellow,
@@ -314,11 +322,7 @@ fn draw_map(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, are
                         QueryResult::NoRecords(_) | QueryResult::Error(_) => Color::Red,
                     },
                 };
-                ctx.print(
-                    resolver.lon,
-                    resolver.lat,
-                    Span::styled("●", Style::new().fg(color).bold()),
-                );
+                ctx.print(lon, lat, Span::styled("●", Style::new().fg(color).bold()));
             }
         });
     frame.render_widget(canvas, area);
@@ -340,7 +344,7 @@ fn draw_map_info(frame: &mut Frame, app: &App, summary: &Summary, complete: bool
             format!(
                 "Majority answer ({}/{} resolvers):",
                 summary.agree,
-                RESOLVERS.len()
+                resolvers::active().len()
             ),
             Style::new().fg(ACCENT).bold(),
         )));


### PR DESCRIPTION
## What

Adds an optional TOML config file so users can add their own resolvers — or replace the built-in list entirely — without rebuilding, plus a CI workflow so tests actually gate PRs.

### Config file

Looked up at `~/.config/dnsglobe/config.toml` (`$XDG_CONFIG_HOME`-aware), with a `DNSGLOBE_CONFIG` env var path override:

```toml
replace = false          # true = replace the built-in list instead of extending it

[[resolvers]]
name = "Corp DNS"        # required
ip = "10.0.0.53"         # required — IPv4 or IPv6
location = "HQ"          # optional — Loc column / location sort
lat = 40.7               # optional — world-map position;
lon = -74.0              #            omit both to leave it off the map
```

Invalid config (bad IP, unknown/typoed key, `lat` without `lon`, `replace = true` with no entries) errors at startup with the offending entry named, before the terminal enters raw mode.

### Implementation

- `src/resolvers.rs`: the curated list stays as static data; `main` installs the merged built-ins + config list behind a `OnceLock` and all call sites read `resolvers::active()`. IPs are parsed once at load instead of per-query `expect()`s.
- `src/config.rs`: serde/toml parsing, path resolution, and validation as a pure, unit-tested merge function.
- Map rendering skips resolvers without coordinates.

### CI

New `ci.yml` runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` on PRs and pushes to main (the existing cargo-dist workflow only builds artifacts).

## Testing

- 9 new unit tests (config parse/merge: extend, replace, IPv6, all error cases; built-in IPs parse and are unique) — 19 total passing
- Verified end-to-end via `--once` with `DNSGLOBE_CONFIG`: replace mode queries exactly the configured resolvers, extend mode shows 35 rows including the custom entry, broken configs exit with clear errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)