### PR TITLE
Add cache-expiry countdowns, TTL advisory, and stale-cache detection

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,26 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use hickory_resolver::proto::rr::RecordType;
 
 use crate::dns::{QueryOutcome, QueryResult};
 use crate::resolvers;
+
+/// Watch-mode re-poll interval; propagation usually moves on TTL boundaries,
+/// so sub-minute polling is plenty.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Slack added on top of a reported TTL before calling a cache stale: we only
+/// sample once per POLL_INTERVAL, so an answer can be up to one interval old,
+/// plus a little headroom for clock skew and in-flight time.
+const TTL_GRACE: Duration = Duration::from_secs(POLL_INTERVAL.as_secs() + 5);
+
+/// Watch-mode observations kept per resolver, oldest dropped first.
+const HISTORY_CAP: usize = 32;
+
+/// TTL at or above which the footer suggests lowering it before a planned
+/// record change (the "drop TTL to 30s a day before migrating" practice).
+pub const ADVISORY_TTL: u32 = 3600;
 
 pub const RECORD_TYPES: &[RecordType] = &[
     RecordType::A,
@@ -60,7 +76,47 @@ pub enum RowState {
     Done {
         result: QueryResult,
         elapsed: Duration,
+        /// When the answer arrived; anchors the cache-expiry countdown.
+        at: Instant,
     },
+}
+
+impl RowState {
+    /// Time left before this row's reported TTL says the cache entry must be
+    /// refetched. None for rows without records.
+    pub fn remaining_ttl(&self, now: Instant) -> Option<Duration> {
+        let RowState::Done {
+            result: QueryResult::Records { min_ttl, .. },
+            at,
+            ..
+        } = self
+        else {
+            return None;
+        };
+        let ttl = Duration::from_secs(u64::from(*min_ttl));
+        Some(ttl.saturating_sub(now.saturating_duration_since(*at)))
+    }
+}
+
+/// One watch-mode answer from a resolver, kept to judge cache behavior over
+/// successive polls.
+#[derive(Debug, Clone)]
+struct Observation {
+    values: Vec<String>,
+    min_ttl: u32,
+    at: Instant,
+}
+
+/// Why a resolver is still serving a non-majority answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TtlVerdict {
+    /// The answer outlived the TTL the resolver itself reported: the cache is
+    /// serving stale data (a resolver that ignores TTLs).
+    PastTtl,
+    /// The TTL jumped back up while the answer stayed the same: the resolver
+    /// did refetch, and *upstream* (e.g. a lagging secondary authoritative
+    /// server) still handed out the old data.
+    Upstream,
 }
 
 #[derive(Debug, Default)]
@@ -105,6 +161,10 @@ pub struct App {
     pub next_poll: Option<Instant>,
     /// Active table ordering, cycled with Ctrl+S.
     pub sort: SortMode,
+    /// Per-resolver answers across watch-mode polls (bounded FIFO). Cleared
+    /// on a fresh query, preserved across re-polls — cache-behavior verdicts
+    /// only exist while watching one domain/type.
+    history: Vec<VecDeque<Observation>>,
 }
 
 impl App {
@@ -122,6 +182,7 @@ impl App {
             auto_refresh: false,
             next_poll: None,
             sort: SortMode::default(),
+            history: vec![VecDeque::new(); resolvers::active().len()],
         }
     }
 
@@ -169,36 +230,146 @@ impl App {
         };
     }
 
-    /// Arm a new query round. Returns what to query, or None if the domain
-    /// input is empty.
-    pub fn begin_query(&mut self) -> Option<(String, RecordType, u64)> {
+    /// Arm a new query round. Returns what to query (all resolvers), or None
+    /// if the domain input is empty.
+    pub fn begin_query(&mut self) -> Option<(String, RecordType, u64, Vec<usize>)> {
         let domain = self.domain.trim().trim_end_matches('.').to_string();
         if domain.is_empty() {
             return None;
         }
         self.generation += 1;
         self.rows = vec![RowState::Pending; resolvers::active().len()];
+        self.history = vec![VecDeque::new(); resolvers::active().len()];
         self.queried = Some((domain.clone(), self.record_type()));
-        Some((domain, self.record_type(), self.generation))
+        let all = (0..self.rows.len()).collect();
+        Some((domain, self.record_type(), self.generation, all))
     }
 
     /// Arm a poll of the last-queried domain/type, ignoring the (possibly
-    /// mid-edit) input field.
-    pub fn begin_requery(&mut self) -> Option<(String, RecordType, u64)> {
+    /// mid-edit) input field. Only re-polls rows whose answer can have
+    /// changed: rows agreeing with the majority are skipped while their TTL
+    /// countdown still runs (a cache can't legally change before expiry), and
+    /// picked up again once it hits zero — so an old-value *majority* still
+    /// gets re-checked and can flip.
+    pub fn begin_requery(&mut self) -> Option<(String, RecordType, u64, Vec<usize>)> {
         let (domain, rtype) = self.queried.clone()?;
+        let summary = self.summary();
+        let now = Instant::now();
+        let indices: Vec<usize> = (0..self.rows.len())
+            .filter(|&i| {
+                let agreeing = matches!(
+                    &self.rows[i],
+                    RowState::Done {
+                        result: QueryResult::Records { .. },
+                        ..
+                    }
+                ) && summary.majority_rows[i];
+                !(agreeing
+                    && self.rows[i]
+                        .remaining_ttl(now)
+                        .is_some_and(|r| !r.is_zero()))
+            })
+            .collect();
+        if indices.is_empty() {
+            return None;
+        }
         self.generation += 1;
-        self.rows = vec![RowState::Pending; resolvers::active().len()];
-        Some((domain, rtype, self.generation))
+        for &i in &indices {
+            self.rows[i] = RowState::Pending;
+        }
+        Some((domain, rtype, self.generation, indices))
     }
 
     pub fn apply(&mut self, outcome: QueryOutcome) {
         if outcome.generation != self.generation {
             return; // stale result from a superseded query round
         }
+        let now = Instant::now();
+        if let QueryResult::Records { values, min_ttl } = &outcome.result {
+            let history = &mut self.history[outcome.resolver_index];
+            if history.len() == HISTORY_CAP {
+                history.pop_front();
+            }
+            history.push_back(Observation {
+                values: values.clone(),
+                min_ttl: *min_ttl,
+                at: now,
+            });
+        }
         self.rows[outcome.resolver_index] = RowState::Done {
             result: outcome.result,
             elapsed: outcome.elapsed,
+            at: now,
         };
+    }
+
+    /// Judge a resolver's cache behavior from its answer history. Only
+    /// meaningful for rows currently *disagreeing* with the majority — the
+    /// caller filters; the same patterns on an agreeing row are normal
+    /// operation.
+    pub fn ttl_verdict(&self, index: usize, now: Instant) -> Option<TtlVerdict> {
+        let history = &self.history[index];
+        let latest = history.back()?;
+        // Tail streak of identical answers; one sample proves nothing.
+        let streak = history
+            .iter()
+            .rev()
+            .take_while(|o| o.values == latest.values)
+            .count();
+        if streak < 2 {
+            return None;
+        }
+        let first = &history[history.len() - streak];
+        // TTL rising within the streak means the resolver refetched and got
+        // the same old data back: the lag is upstream, not this cache.
+        let mut prev_ttl = first.min_ttl;
+        for obs in history.iter().skip(history.len() - streak + 1) {
+            if obs.min_ttl > prev_ttl {
+                return Some(TtlVerdict::Upstream);
+            }
+            prev_ttl = obs.min_ttl;
+        }
+        let deadline = first.at + Duration::from_secs(u64::from(first.min_ttl)) + TTL_GRACE;
+        (now > deadline).then_some(TtlVerdict::PastTtl)
+    }
+
+    /// Estimated configured TTL: the max reported TTL across majority rows.
+    /// A resolver that just refetched reports (nearly) the full configured
+    /// value, so the max over the fleet is within seconds of the zone's TTL.
+    pub fn estimated_ttl(&self, summary: &Summary) -> Option<u32> {
+        self.rows
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| summary.majority_rows[i])
+            .filter_map(|(_, row)| match row {
+                RowState::Done {
+                    result: QueryResult::Records { min_ttl, .. },
+                    ..
+                } => Some(*min_ttl),
+                _ => None,
+            })
+            .max()
+    }
+
+    /// Worst-case wait until every non-majority cache must have refetched:
+    /// the max remaining TTL across differing rows. None when nothing
+    /// differs (or differing rows carry no records).
+    pub fn stale_expiry_bound(&self, summary: &Summary, now: Instant) -> Option<Duration> {
+        self.rows
+            .iter()
+            .enumerate()
+            .filter(|&(i, row)| {
+                !summary.majority_rows[i]
+                    && matches!(
+                        row,
+                        RowState::Done {
+                            result: QueryResult::Records { .. },
+                            ..
+                        }
+                    )
+            })
+            .filter_map(|(_, row)| row.remaining_ttl(now))
+            .max()
     }
 
     pub fn in_flight(&self) -> bool {
@@ -221,15 +392,18 @@ impl App {
             // table's "✓ OK until the round settles" display.
             SortMode::Status => {
                 let in_flight = self.in_flight();
+                let now = Instant::now();
                 order.sort_by_key(|&i| match &self.rows[i] {
                     RowState::Done { result, .. } => match result {
-                        QueryResult::Records { .. } if in_flight || summary.majority_rows[i] => 3,
-                        QueryResult::Records { .. } => 0, // differs
-                        QueryResult::NoRecords(_) => 1,
-                        QueryResult::Error(_) => 2,
+                        QueryResult::Records { .. } if in_flight || summary.majority_rows[i] => 4,
+                        // Misbehaving caches are the most actionable rows.
+                        QueryResult::Records { .. } if self.ttl_verdict(i, now).is_some() => 0,
+                        QueryResult::Records { .. } => 1, // differs
+                        QueryResult::NoRecords(_) => 2,
+                        QueryResult::Error(_) => 3,
                     },
-                    RowState::Pending => 4,
-                    RowState::Idle => 5,
+                    RowState::Pending => 5,
+                    RowState::Idle => 6,
                 });
             }
             SortMode::Answer => order.sort_by(|&a, &b| {
@@ -342,6 +516,26 @@ impl App {
     }
 }
 
+/// Compact human duration for countdowns and TTLs: `42s`, `4m10s`, `23h59m`,
+/// `2d3h`. Two units max keeps it within a narrow table column.
+pub fn fmt_secs(total: u64) -> String {
+    let (days, hours, mins, secs) = (
+        total / 86_400,
+        (total % 86_400) / 3_600,
+        (total % 3_600) / 60,
+        total % 60,
+    );
+    if days > 0 {
+        format!("{days}d{hours}h")
+    } else if hours > 0 {
+        format!("{hours}h{mins:02}m")
+    } else if mins > 0 {
+        format!("{mins}m{secs:02}s")
+    } else {
+        format!("{secs}s")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -356,6 +550,7 @@ mod tests {
                     min_ttl: 60,
                 },
                 elapsed: Duration::from_millis(10),
+                at: Instant::now(),
             })
             .collect();
         app
@@ -399,6 +594,7 @@ mod tests {
         app.rows.push(RowState::Done {
             result: QueryResult::Error("refused".into()),
             elapsed: Duration::from_secs(3),
+            at: Instant::now(),
         });
         let s = app.summary();
         assert_eq!(s.groups, 1);
@@ -433,6 +629,7 @@ mod tests {
         app.rows.push(RowState::Done {
             result: QueryResult::Error("timeout".into()),
             elapsed: Duration::from_secs(3),
+            at: Instant::now(),
         });
         app.sort = SortMode::Status;
         let summary = app.summary();
@@ -446,6 +643,165 @@ mod tests {
         assert_eq!(order, vec![0, 1, 2, 3]);
     }
 
+    /// A `now` safely in the future so tests can place observations "in the
+    /// past" relative to it without risking Instant underflow on a
+    /// freshly-booted machine.
+    fn future_now() -> Instant {
+        Instant::now() + Duration::from_secs(100_000)
+    }
+
+    fn obs(values: &[&str], min_ttl: u32, now: Instant, ago: u64) -> Observation {
+        Observation {
+            values: values.iter().map(|v| v.to_string()).collect(),
+            min_ttl,
+            at: now - Duration::from_secs(ago),
+        }
+    }
+
+    #[test]
+    fn fmt_secs_is_compact_two_units() {
+        assert_eq!(fmt_secs(42), "42s");
+        assert_eq!(fmt_secs(250), "4m10s");
+        assert_eq!(fmt_secs(3600), "1h00m");
+        assert_eq!(fmt_secs(86_399), "23h59m");
+        assert_eq!(fmt_secs(90_000), "1d1h");
+    }
+
+    #[test]
+    fn verdict_needs_at_least_two_observations() {
+        let mut app = App::new("example.com".into());
+        let now = future_now();
+        app.history[0] = VecDeque::from([obs(&["old"], 60, now, 500)]);
+        assert_eq!(app.ttl_verdict(0, now), None);
+    }
+
+    #[test]
+    fn same_answer_past_reported_ttl_is_a_stale_cache() {
+        let mut app = App::new("example.com".into());
+        let now = future_now();
+        // First seen 120s ago with a 60s TTL: deadline (60s + grace) passed,
+        // TTL never rose, answer unchanged → the cache is ignoring its TTL.
+        app.history[0] = VecDeque::from([obs(&["old"], 60, now, 120), obs(&["old"], 60, now, 10)]);
+        assert_eq!(app.ttl_verdict(0, now), Some(TtlVerdict::PastTtl));
+    }
+
+    #[test]
+    fn same_answer_within_ttl_is_no_verdict() {
+        let mut app = App::new("example.com".into());
+        let now = future_now();
+        app.history[0] = VecDeque::from([obs(&["old"], 300, now, 60), obs(&["old"], 300, now, 10)]);
+        assert_eq!(app.ttl_verdict(0, now), None);
+    }
+
+    #[test]
+    fn ttl_rising_with_same_answer_means_upstream_lag() {
+        let mut app = App::new("example.com".into());
+        let now = future_now();
+        // TTL jumped 60 → 300: the resolver refetched and the authority
+        // handed the old data back — not this cache's fault.
+        app.history[0] = VecDeque::from([obs(&["old"], 60, now, 100), obs(&["old"], 300, now, 40)]);
+        assert_eq!(app.ttl_verdict(0, now), Some(TtlVerdict::Upstream));
+    }
+
+    #[test]
+    fn answer_change_resets_the_streak() {
+        let mut app = App::new("example.com".into());
+        let now = future_now();
+        // Old answer lingered way past TTL, but the *current* answer is one
+        // fresh sample: no verdict against the new streak.
+        app.history[0] = VecDeque::from([
+            obs(&["old"], 60, now, 500),
+            obs(&["old"], 60, now, 400),
+            obs(&["new"], 60, now, 10),
+        ]);
+        assert_eq!(app.ttl_verdict(0, now), None);
+    }
+
+    #[test]
+    fn history_is_a_bounded_fifo() {
+        let mut app = App::new("example.com".into());
+        for i in 0..(HISTORY_CAP + 5) {
+            app.apply(QueryOutcome {
+                resolver_index: 0,
+                generation: 0,
+                result: QueryResult::Records {
+                    values: vec![format!("v{i}")],
+                    min_ttl: 60,
+                },
+                elapsed: Duration::from_millis(10),
+            });
+        }
+        assert_eq!(app.history[0].len(), HISTORY_CAP);
+        // Oldest entries were dropped first.
+        assert_eq!(app.history[0].front().unwrap().values, vec!["v5"]);
+    }
+
+    #[test]
+    fn requery_skips_agreeing_rows_until_their_ttl_expires() {
+        let mut app = app_with_answers(&[&["new"], &["new"], &["old"]]);
+        app.queried = Some(("example.com".into(), RecordType::A));
+        // Majority rows are fresh (60s TTL): only the differing row re-polls.
+        let (_, _, _, indices) = app.begin_requery().unwrap();
+        assert_eq!(indices, vec![2]);
+        assert!(matches!(app.rows[2], RowState::Pending));
+        assert!(matches!(app.rows[0], RowState::Done { .. }));
+    }
+
+    #[test]
+    fn requery_repolls_agreeing_rows_once_expired_and_all_errors() {
+        let mut app = app_with_answers(&[&["new"], &["new"], &["old"]]);
+        // Row 0's cache entry has expired (TTL 0): even though it agrees,
+        // its answer can now legally change, so it re-polls.
+        if let RowState::Done {
+            result: QueryResult::Records { min_ttl, .. },
+            ..
+        } = &mut app.rows[0]
+        {
+            *min_ttl = 0;
+        }
+        app.rows.push(RowState::Done {
+            result: QueryResult::Error("timeout".into()),
+            elapsed: Duration::from_secs(3),
+            at: Instant::now(),
+        });
+        app.queried = Some(("example.com".into(), RecordType::A));
+        let (_, _, _, indices) = app.begin_requery().unwrap();
+        assert_eq!(indices, vec![0, 2, 3]);
+    }
+
+    #[test]
+    fn estimated_ttl_is_max_over_majority_rows_only() {
+        let mut app = app_with_answers(&[&["x"], &["x"], &["y"]]);
+        let ttls = [300u32, 3600, 999_999];
+        for (row, ttl) in app.rows.iter_mut().zip(ttls) {
+            if let RowState::Done {
+                result: QueryResult::Records { min_ttl, .. },
+                ..
+            } = row
+            {
+                *min_ttl = ttl;
+            }
+        }
+        let summary = app.summary();
+        // The differing row's huge TTL must not leak into the estimate.
+        assert_eq!(app.estimated_ttl(&summary), Some(3600));
+    }
+
+    #[test]
+    fn stale_expiry_bound_covers_only_differing_rows() {
+        let app = app_with_answers(&[&["new"], &["new"], &["old"]]);
+        let summary = app.summary();
+        let bound = app.stale_expiry_bound(&summary, Instant::now()).unwrap();
+        // The differing row was just answered with a 60s TTL.
+        assert!(bound <= Duration::from_secs(60));
+        assert!(bound > Duration::from_secs(50));
+
+        // Full agreement → nothing stale → no bound.
+        let app = app_with_answers(&[&["x"], &["x"]]);
+        let summary = app.summary();
+        assert_eq!(app.stale_expiry_bound(&summary, Instant::now()), None);
+    }
+
     #[test]
     fn nxdomain_counts_as_responding_and_blocks_full_propagation() {
         // "No such record" is a real propagation signal: that resolver
@@ -454,6 +810,7 @@ mod tests {
         app.rows.push(RowState::Done {
             result: QueryResult::NoRecords("NXDOMAIN".into()),
             elapsed: Duration::from_millis(20),
+            at: Instant::now(),
         });
         let s = app.summary();
         assert_eq!(s.responding, 3);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,8 @@ use futures::StreamExt;
 use hickory_resolver::proto::rr::RecordType;
 use tokio::sync::mpsc;
 
-use app::App;
+use app::{App, POLL_INTERVAL};
 use dns::QueryOutcome;
-
-/// Watch-mode re-poll interval; propagation usually moves on TTL boundaries,
-/// so sub-minute polling is plenty.
-const POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -187,12 +183,12 @@ fn poll_query(app: &mut App, tx: &mpsc::UnboundedSender<QueryOutcome>) {
 
 fn spawn_round(
     tx: &mpsc::UnboundedSender<QueryOutcome>,
-    (domain, rtype, generation): (String, RecordType, u64),
+    (domain, rtype, generation, indices): (String, RecordType, u64, Vec<usize>),
 ) {
-    for (resolver_index, resolver) in resolvers::active().iter().enumerate() {
+    for resolver_index in indices {
         let tx = tx.clone();
         let domain = domain.clone();
-        let server: IpAddr = resolver.ip;
+        let server: IpAddr = resolvers::active()[resolver_index].ip;
         tokio::spawn(async move {
             let (result, elapsed) = dns::query(server, domain, rtype).await;
             let _ = tx.send(QueryOutcome {
@@ -212,14 +208,14 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
         .iter()
         .position(|t| *t == rtype)
         .unwrap_or(0);
-    let (domain, rtype, generation) = app
+    let (domain, rtype, generation, indices) = app
         .begin_query()
         .ok_or_else(|| anyhow::anyhow!("empty domain"))?;
 
     let mut tasks = tokio::task::JoinSet::new();
-    for (resolver_index, resolver) in resolvers::active().iter().enumerate() {
+    for resolver_index in indices {
         let domain = domain.clone();
-        let server: IpAddr = resolver.ip;
+        let server: IpAddr = resolvers::active()[resolver_index].ip;
         tasks.spawn(async move {
             let (result, elapsed) = dns::query(server, domain, rtype).await;
             QueryOutcome {
@@ -238,7 +234,9 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
     println!("{domain} {rtype}\n");
     for (i, (resolver, row)) in resolvers::active().iter().zip(&app.rows).enumerate() {
         let line = match row {
-            app::RowState::Done { result, elapsed } => match result {
+            app::RowState::Done {
+                result, elapsed, ..
+            } => match result {
                 dns::QueryResult::Records { values, min_ttl } => {
                     let status = if summary.majority_rows[i] {
                         "OK     "
@@ -277,6 +275,16 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
             summary.agree,
             summary.responding,
             summary.majority_values.join(", ")
+        );
+    }
+    if summary.responding > 0
+        && summary.agree == summary.responding
+        && let Some(est) = app.estimated_ttl(&summary)
+        && est >= app::ADVISORY_TTL
+    {
+        println!(
+            "note: TTL ≈ {} — planning a record change? lower the TTL first, then wait one old-TTL period before switching.",
+            app::fmt_secs(u64::from(est))
         );
     }
     Ok(())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -5,14 +7,20 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::canvas::{Canvas, Map, MapResolution};
 use ratatui::widgets::{Block, Borders, Cell, LineGauge, Paragraph, Row, Table, TableState};
 
-use crate::app::{App, RECORD_TYPES, RowState, SPINNER, Summary};
+use crate::app::{
+    ADVISORY_TTL, App, RECORD_TYPES, RowState, SPINNER, Summary, TtlVerdict, fmt_secs,
+};
 use crate::dns::QueryResult;
 use crate::resolvers;
 
 const ACCENT: Color = Color::Cyan;
-/// Table needs ~93 cols; only show the map when there's room for both.
-const MIN_WIDTH_FOR_MAP: u16 = 150;
-const TABLE_WIDTH: u16 = 96;
+/// Table needs ~102 cols; only show the map when there's room for both.
+const MIN_WIDTH_FOR_MAP: u16 = 156;
+const TABLE_WIDTH: u16 = 102;
+/// Dot/status color for a cache serving an answer past its own TTL.
+const STALE_COLOR: Color = Color::LightRed;
+/// Dot/status color for "refetched but upstream still serves the old data".
+const UPSTREAM_COLOR: Color = Color::LightBlue;
 const MAP_MAX_WIDTH: u16 = 170;
 /// Map bounds: lon −170..180, lat −55..72 (poles cropped).
 const MAP_LON_SPAN: f64 = 350.0;
@@ -29,10 +37,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // flagging outliers mid-flight makes rows flap as the majority shifts.
     let complete = summary.done > 0 && !app.in_flight();
 
+    let advisory = ttl_advisory(app, &summary, complete);
     let [header, body, footer] = Layout::vertical([
         Constraint::Length(4),
         Constraint::Min(6),
-        Constraint::Length(2),
+        Constraint::Length(if advisory.is_some() { 3 } else { 2 }),
     ])
     .areas(frame.area());
 
@@ -66,7 +75,23 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_map(frame, app, &summary, complete, map_area);
         draw_map_info(frame, app, &summary, complete, info_area);
     }
-    draw_footer(frame, app, &summary, footer);
+    draw_footer(frame, app, &summary, advisory, footer);
+}
+
+/// One-line "lower your TTL before migrating" hint, shown once a round has
+/// settled with full agreement (the planning phase — mid-migration the advice
+/// comes too late) and the zone's TTL is long.
+fn ttl_advisory(app: &App, summary: &Summary, complete: bool) -> Option<String> {
+    if !complete || summary.responding == 0 || summary.agree != summary.responding {
+        return None;
+    }
+    let est = app.estimated_ttl(summary)?;
+    (est >= ADVISORY_TTL).then(|| {
+        format!(
+            "TTL ≈ {} — planning a record change? Lower the TTL first, then wait one old-TTL period before switching.",
+            fmt_secs(u64::from(est))
+        )
+    })
 }
 
 fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
@@ -142,6 +167,16 @@ fn draw_gauge(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
         if summary.errors > 0 {
             label.push_str(&format!(" · {} unreachable", summary.errors));
         }
+        // Worst case, every disagreeing cache must refetch within this — the
+        // number the whole watch is really about.
+        if summary.agree < summary.responding
+            && let Some(bound) = app.stale_expiry_bound(summary, Instant::now())
+        {
+            label.push_str(&format!(
+                " · old answers expire in ≤ {}",
+                fmt_secs(bound.as_secs())
+            ));
+        }
         if summary.responding > 0 && summary.agree == summary.responding {
             label.push_str(" · complete ");
         } else if let Some(at) = app.next_poll {
@@ -164,17 +199,21 @@ fn draw_gauge(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
 }
 
 fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, area: Rect) {
-    let header = Row::new(["Resolver", "Loc", "IP", "Time", "TTL", "Status", "Answer"])
-        .style(Style::new().fg(ACCENT).bold());
+    let header = Row::new([
+        "Resolver", "Loc", "IP", "Time", "TTL", "Exp", "Status", "Answer",
+    ])
+    .style(Style::new().fg(ACCENT).bold());
+    let now = Instant::now();
 
     let rows = app
         .display_order(summary)
         .into_iter()
         .map(|i| (i, (&resolvers::active()[i], &app.rows[i])))
         .map(|(i, (resolver, state))| {
-            let (time_cell, ttl_cell, status_cell, answer_cell) = match state {
+            let (time_cell, ttl_cell, exp_cell, status_cell, answer_cell) = match state {
                 RowState::Idle => (
                     Cell::from("—"),
+                    Cell::from(""),
                     Cell::from(""),
                     Cell::from(Span::styled("idle", Style::new().fg(Color::DarkGray))),
                     Cell::from(""),
@@ -182,13 +221,16 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                 RowState::Pending => (
                     Cell::from("…"),
                     Cell::from(""),
+                    Cell::from(""),
                     Cell::from(Span::styled(
                         format!("{} query", SPINNER[app.spinner_frame % SPINNER.len()]),
                         Style::new().fg(Color::Yellow),
                     )),
                     Cell::from(""),
                 ),
-                RowState::Done { result, elapsed } => {
+                RowState::Done {
+                    result, elapsed, ..
+                } => {
                     let ms = elapsed.as_millis();
                     let time_style = if ms < 100 {
                         Style::new().fg(Color::Green)
@@ -201,21 +243,46 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                     match result {
                         QueryResult::Records { values, min_ttl } => {
                             let matches_majority = !complete || summary.majority_rows[i];
-                            let (status, style) = if matches_majority {
-                                ("✓ OK", Style::new().fg(Color::Green).bold())
+                            let verdict = if matches_majority {
+                                None
                             } else {
-                                ("≠ DIFFERS", Style::new().fg(Color::Magenta).bold())
+                                app.ttl_verdict(i, now)
+                            };
+                            let (status, style) = match verdict {
+                                Some(TtlVerdict::PastTtl) => {
+                                    ("! PAST TTL", Style::new().fg(STALE_COLOR).bold())
+                                }
+                                Some(TtlVerdict::Upstream) => {
+                                    ("↻ UPSTREAM", Style::new().fg(UPSTREAM_COLOR).bold())
+                                }
+                                None if matches_majority => {
+                                    ("✓ OK", Style::new().fg(Color::Green).bold())
+                                }
+                                None => ("≠ DIFFERS", Style::new().fg(Color::Magenta).bold()),
+                            };
+                            // Live countdown to the moment this cache entry
+                            // must be refetched. For disagreeing rows this is
+                            // "how much longer the old answer can survive
+                            // here", so it carries the status color.
+                            let remaining = state.remaining_ttl(now).unwrap_or_default().as_secs();
+                            let exp = if remaining == 0 {
+                                Span::styled("expired", Style::new().fg(Color::DarkGray).italic())
+                            } else if matches_majority {
+                                Span::styled(fmt_secs(remaining), Style::new().fg(Color::DarkGray))
+                            } else {
+                                Span::styled(fmt_secs(remaining), style)
                             };
                             (
                                 time,
                                 Cell::from(format!("{min_ttl}")),
+                                Cell::from(exp),
                                 Cell::from(Span::styled(status, style)),
                                 Cell::from(Span::styled(
                                     values.join(", "),
                                     if matches_majority {
                                         Style::new()
                                     } else {
-                                        Style::new().fg(Color::Magenta)
+                                        Style::new().fg(style.fg.unwrap_or(Color::Magenta))
                                     },
                                 )),
                             )
@@ -223,11 +290,13 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                         QueryResult::NoRecords(code) => (
                             time,
                             Cell::from(""),
+                            Cell::from(""),
                             Cell::from(Span::styled("∅ NONE", Style::new().fg(Color::Red).bold())),
                             Cell::from(Span::styled(code.clone(), Style::new().fg(Color::Red))),
                         ),
                         QueryResult::Error(message) => (
                             time,
+                            Cell::from(""),
                             Cell::from(""),
                             Cell::from(Span::styled("✗ ERR", Style::new().fg(Color::Red).bold())),
                             Cell::from(Span::styled(
@@ -250,6 +319,7 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                 )),
                 time_cell,
                 ttl_cell,
+                exp_cell,
                 status_cell,
                 answer_cell,
             ])
@@ -263,7 +333,8 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
             Constraint::Length(15),
             Constraint::Length(7),
             Constraint::Length(6),
-            Constraint::Length(9),
+            Constraint::Length(7),
+            Constraint::Length(10),
             Constraint::Min(20),
         ],
     )
@@ -304,6 +375,7 @@ fn draw_map(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, are
                 color: Color::DarkGray,
                 resolution: MapResolution::High,
             });
+            let now = Instant::now();
             for (i, (resolver, state)) in resolvers::active().iter().zip(&app.rows).enumerate() {
                 let Some((lat, lon)) = resolver.coords else {
                     continue; // config resolver without map coordinates
@@ -316,7 +388,11 @@ fn draw_map(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, are
                             if !complete || summary.majority_rows[i] {
                                 Color::Green
                             } else {
-                                Color::Magenta
+                                match app.ttl_verdict(i, now) {
+                                    Some(TtlVerdict::PastTtl) => STALE_COLOR,
+                                    Some(TtlVerdict::Upstream) => UPSTREAM_COLOR,
+                                    None => Color::Magenta,
+                                }
                             }
                         }
                         QueryResult::NoRecords(_) | QueryResult::Error(_) => Color::Red,
@@ -335,6 +411,8 @@ fn draw_map_info(frame: &mut Frame, app: &App, summary: &Summary, complete: bool
     let mut lines = vec![Line::from(vec![
         Span::styled("● agrees  ", Style::new().fg(Color::Green)),
         Span::styled("● differs  ", Style::new().fg(Color::Magenta)),
+        Span::styled("● past-ttl  ", Style::new().fg(STALE_COLOR)),
+        Span::styled("● upstream  ", Style::new().fg(UPSTREAM_COLOR)),
         Span::styled("● error  ", Style::new().fg(Color::Red)),
         Span::styled("● pending", Style::new().fg(Color::Yellow)),
     ])];
@@ -372,7 +450,13 @@ fn draw_map_info(frame: &mut Frame, app: &App, summary: &Summary, complete: bool
     );
 }
 
-fn draw_footer(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
+fn draw_footer(
+    frame: &mut Frame,
+    app: &App,
+    summary: &Summary,
+    advisory: Option<String>,
+    area: Rect,
+) {
     let mut status = Line::default();
     if let Some((domain, rtype)) = &app.queried {
         status.push_span(Span::styled(
@@ -407,8 +491,24 @@ fn draw_footer(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
         " type to edit · ←/→ move cursor · Enter query+watch · Ctrl+R watch on/off · Ctrl+S sort · Tab record type · ↑/↓ scroll · Esc quit",
         Style::new().fg(Color::DarkGray),
     ));
-    let [status_area, keys_area] =
-        Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).areas(area);
-    frame.render_widget(Paragraph::new(status), status_area);
-    frame.render_widget(Paragraph::new(keys), keys_area);
+    if let Some(advisory) = advisory {
+        let advisory_line = Line::from(vec![
+            Span::styled(" ℹ ", Style::new().fg(ACCENT)),
+            Span::styled(advisory, Style::new().fg(Color::DarkGray).italic()),
+        ]);
+        let [advisory_area, status_area, keys_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .areas(area);
+        frame.render_widget(Paragraph::new(advisory_line), advisory_area);
+        frame.render_widget(Paragraph::new(status), status_area);
+        frame.render_widget(Paragraph::new(keys), keys_area);
+    } else {
+        let [status_area, keys_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).areas(area);
+        frame.render_widget(Paragraph::new(status), status_area);
+        frame.render_widget(Paragraph::new(keys), keys_area);
+    }
 }


### PR DESCRIPTION
Addresses the main feedback threads from the [HN discussion](https://news.ycombinator.com/item?id=48798313): DNS changes aren't pushed geographically — each cache independently expires and refetches. These features reframe the tool around that reality.

## 1. Live cache-expiry countdown (`Exp` column)

- New column next to the static `TTL` showing a live countdown to when each resolver's cache entry must be refetched. For rows disagreeing with the majority this is the worst-case survival time of the old answer, rendered in the status color.
- The gauge shows the fleet-wide bound while propagation is incomplete: `old answers expire in ≤ 4m10s` — the number a watch is really about.
- Watch mode now skips re-polling resolvers that agree with the majority while their TTL countdown still runs (a cache can't legally change before expiry), and picks them up again once it hits zero. The expiry condition matters: a permanent skip would freeze an old-value majority early in a migration and it could never flip.

## 2. TTL advisory

Once a round settles with full agreement and the zone's TTL is ≥ 1h (estimated as the max reported TTL across majority rows — a freshly-refetched cache reports nearly the full configured value), a footer hint (and a note in `--once`) suggests the standard practice: lower the TTL before a planned record change, then wait one old-TTL period.

## 3. Cache-behavior verdicts

Watch mode keeps a bounded FIFO (32 entries per resolver, cleared on a fresh query) of answers and distinguishes two failure modes for rows stuck on a non-majority answer:

- `! PAST TTL` — the answer outlived the TTL the resolver itself reported and the TTL never rose: the cache is ignoring TTLs.
- `↻ UPSTREAM` — the TTL jumped back up with the same old answer: the resolver *did* refetch and an upstream source (e.g. a lagging secondary authoritative server) served stale data — not the cache's fault.

Both get distinct map colors, legend entries, and sort to the top under status ordering.

## Notes

- Table width grew to ~102 cols; the map threshold moved from 150 to 156 columns. The Answer column narrows to ~20 chars when the map is shown; the full majority answer remains in the map info panel.
- 11 new unit tests: both verdicts, streak reset on answer change, FIFO cap, selective re-polling (fresh, expired, and error rows), and advisory estimation excluding non-majority rows.
- Verified live against example.com / google.com (`--once` and TUI): countdown ticks, advisory fires on `example.com NS` (TTL ≈ 10h51m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)