### PR TITLE
Add geolocation for anycast resolvers via their identification queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ On terminals ≥150 columns wide, a world map appears on the right with one
 dot per resolver, colored by status (green agrees, magenta differs, red
 error, yellow in flight).
 
+Anycast networks are asked which of their sites is answering you: Quad9
+(`TXT id.server.on.quad9.net`), Cloudflare (`CH TXT id.server`), Google
+(egress subnet via `TXT o-o.myaddr.l.google.com` matched against
+`TXT locations.publicdns.goog`), OpenDNS (`TXT debug.opendns.com`),
+CleanBrowsing, and Neustar UltraDNS. The discovered site shows in the Loc
+column as `→YUL`-style codes, and the resolver's map dot moves to the POP
+actually serving your queries.
+
 ## Usage
 
 Install:
@@ -95,7 +103,9 @@ with no resolvers) is reported at startup with the offending entry named.
 ## Notes
 
 - Several resolvers are anycast networks, so the responding node is the one
-  nearest to you; the location column is the operator's home region.
+  nearest to you. Networks with an identification query report the actual
+  answering site (`→YUL`); for the rest the location column is the
+  operator's home region.
 - The built-in resolver list lives in `src/resolvers.rs`; use the config file
   above to extend or replace it without rebuilding. Every built-in entry was
   verified to answer external queries; many well-known ISP resolvers (and,

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use hickory_resolver::proto::rr::RecordType;
 
 use crate::dns::{QueryOutcome, QueryResult};
 use crate::resolvers;
+use crate::sites::Site;
 
 /// Watch-mode re-poll interval; propagation usually moves on TTL boundaries,
 /// so sub-minute polling is plenty.
@@ -161,6 +162,11 @@ pub struct App {
     pub next_poll: Option<Instant>,
     /// Active table ordering, cycled with Ctrl+S.
     pub sort: SortMode,
+    /// Per-resolver anycast site discovered by that operator's identification
+    /// query (issue #6): which POP is actually answering us. None = no probe
+    /// or probe failed. Session-static — the site depends on our network
+    /// path, not on the queried domain.
+    pub sites: Vec<Option<Site>>,
     /// Per-resolver answers across watch-mode polls (bounded FIFO). Cleared
     /// on a fresh query, preserved across re-polls — cache-behavior verdicts
     /// only exist while watching one domain/type.
@@ -182,8 +188,27 @@ impl App {
             auto_refresh: false,
             next_poll: None,
             sort: SortMode::default(),
+            sites: vec![None; resolvers::active().len()],
             history: vec![VecDeque::new(); resolvers::active().len()],
         }
+    }
+
+    /// Where this resolver's answers come from, as shown in the Loc column:
+    /// the discovered anycast site when known, else the configured location.
+    pub fn effective_location(&self, index: usize) -> &str {
+        match &self.sites[index] {
+            Some(site) => &site.code,
+            None => &resolvers::active()[index].location,
+        }
+    }
+
+    /// Map position for this resolver: the discovered site when we know its
+    /// coordinates, else the configured (operator home) position.
+    pub fn effective_coords(&self, index: usize) -> Option<(f64, f64)> {
+        self.sites[index]
+            .as_ref()
+            .and_then(|site| site.coords)
+            .or(resolvers::active()[index].coords)
     }
 
     pub fn record_type(&self) -> RecordType {
@@ -381,7 +406,7 @@ impl App {
         let mut order: Vec<usize> = (0..self.rows.len()).collect();
         match self.sort {
             SortMode::Resolver => {}
-            SortMode::Location => order.sort_by_key(|&i| resolvers::active()[i].location.as_str()),
+            SortMode::Location => order.sort_by_key(|&i| self.effective_location(i)),
             // Fastest first; rows without a result sink to the bottom.
             SortMode::Time => order.sort_by_key(|&i| match &self.rows[i] {
                 RowState::Done { elapsed, .. } => *elapsed,

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,7 @@ fn resolver_list(config: Config) -> Result<Vec<Resolver>> {
             location: entry.location,
             ip,
             coords,
+            probe: None,
         });
     }
     if list.is_empty() {

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -6,7 +6,7 @@ use hickory_resolver::config::{NameServerConfig, ResolveHosts, ResolverConfig};
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::net::{DnsError, NetError};
 use hickory_resolver::proto::op::ResponseCode;
-use hickory_resolver::proto::rr::RecordType;
+use hickory_resolver::proto::rr::{RData, RecordType};
 
 const QUERY_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -33,9 +33,9 @@ pub struct QueryOutcome {
     pub elapsed: Duration,
 }
 
-/// Query a single upstream resolver directly (no cache, single attempt) so
-/// each server's own view of the record is what we measure.
-pub async fn query(server: IpAddr, domain: String, rtype: RecordType) -> (QueryResult, Duration) {
+/// One-server resolver going straight at `server` (no cache, single attempt)
+/// so that server's own view of a record is what we measure.
+fn build_resolver(server: IpAddr) -> Result<TokioResolver, NetError> {
     let mut config = ResolverConfig::default();
     // One server entry with both UDP and TCP connections: hickory retries
     // over TCP when a UDP answer comes back truncated (large TXT sets, long
@@ -51,8 +51,13 @@ pub async fn query(server: IpAddr, domain: String, rtype: RecordType) -> (QueryR
     opts.cache_size = 0;
     opts.use_hosts_file = ResolveHosts::Never;
     opts.edns0 = true; // allow >512-byte UDP answers
+    builder.build()
+}
 
-    let resolver = match builder.build() {
+/// Query a single upstream resolver directly (no cache, single attempt) so
+/// each server's own view of the record is what we measure.
+pub async fn query(server: IpAddr, domain: String, rtype: RecordType) -> (QueryResult, Duration) {
+    let resolver = match build_resolver(server) {
         Ok(resolver) => resolver,
         Err(err) => {
             return (
@@ -110,6 +115,78 @@ pub async fn query(server: IpAddr, domain: String, rtype: RecordType) -> (QueryR
     };
 
     (result, elapsed)
+}
+
+/// IN TXT query returning each TXT character-string separately (a record's
+/// strings are answers like `"prefix code"` entries — joining them would
+/// destroy the structure). Used by the anycast site probes; None on any
+/// failure, since a failed probe just means "site unknown".
+pub async fn txt_strings(server: IpAddr, name: &str) -> Option<Vec<String>> {
+    let resolver = build_resolver(server).ok()?;
+    let lookup = tokio::time::timeout(
+        QUERY_TIMEOUT + Duration::from_secs(1),
+        resolver.lookup(name, RecordType::TXT),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    let strings: Vec<String> = lookup
+        .answers()
+        .iter()
+        .filter_map(|record| match &record.data {
+            RData::TXT(txt) => Some(&txt.txt_data),
+            _ => None,
+        })
+        .flat_map(|data| data.iter())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect();
+    (!strings.is_empty()).then_some(strings)
+}
+
+/// CHAOS-class TXT query (`id.server` etc.), which the high-level resolver
+/// can't express — hand-rolled over UDP. Answers are tiny, so no truncation
+/// handling. None on any failure.
+pub async fn chaos_txt(server: IpAddr, name: &str) -> Option<Vec<String>> {
+    use hickory_resolver::proto::op::{Message, Query};
+    use hickory_resolver::proto::rr::{DNSClass, Name};
+    use std::str::FromStr;
+
+    let mut query = Query::query(Name::from_str(name).ok()?, RecordType::TXT);
+    query.set_query_class(DNSClass::CH);
+    let mut message = Message::query();
+    message.metadata.recursion_desired = false;
+    message.add_query(query);
+    let request = message.to_vec().ok()?;
+
+    let bind: std::net::SocketAddr = match server {
+        IpAddr::V4(_) => ([0, 0, 0, 0], 0).into(),
+        IpAddr::V6(_) => (std::net::Ipv6Addr::UNSPECIFIED, 0).into(),
+    };
+    let socket = tokio::net::UdpSocket::bind(bind).await.ok()?;
+    // Connecting filters responses to this server's address.
+    socket.connect((server, 53)).await.ok()?;
+    socket.send(&request).await.ok()?;
+
+    let mut buf = [0u8; 4096];
+    let len = tokio::time::timeout(QUERY_TIMEOUT, socket.recv(&mut buf))
+        .await
+        .ok()?
+        .ok()?;
+    let response = Message::from_vec(&buf[..len]).ok()?;
+    if response.metadata.id != message.metadata.id {
+        return None;
+    }
+    let strings: Vec<String> = response
+        .answers
+        .iter()
+        .filter_map(|record| match &record.data {
+            RData::TXT(txt) => Some(&txt.txt_data),
+            _ => None,
+        })
+        .flat_map(|data| data.iter())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect();
+    (!strings.is_empty()).then_some(strings)
 }
 
 fn short_error(message: String) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod config;
 mod dns;
 mod resolvers;
+mod sites;
 mod ui;
 
 use std::net::IpAddr;
@@ -54,7 +55,12 @@ async fn run_tui(mut terminal: ratatui::DefaultTerminal, initial_domain: String)
     // Worker tasks send results here; keeping `tx` alive in this scope means
     // `rx.recv()` never observes a closed channel.
     let (tx, mut rx) = mpsc::unbounded_channel::<QueryOutcome>();
+    // Anycast site discoveries arrive on their own channel: they have no
+    // generation — the answering POP depends on our network path, not on
+    // what domain is being checked.
+    let (site_tx, mut site_rx) = mpsc::unbounded_channel::<(usize, sites::Site)>();
 
+    spawn_site_probes(&site_tx);
     if auto_query {
         spawn_queries(&mut app, &tx);
     }
@@ -94,6 +100,9 @@ async fn run_tui(mut terminal: ratatui::DefaultTerminal, initial_domain: String)
                         app.next_poll = Some(Instant::now() + POLL_INTERVAL);
                     }
                 }
+            }
+            Some((index, site)) = site_rx.recv() => {
+                app.sites[index] = Some(site);
             }
             _ = tick.tick() => {
                 if app.in_flight() {
@@ -181,6 +190,23 @@ fn poll_query(app: &mut App, tx: &mpsc::UnboundedSender<QueryOutcome>) {
     spawn_round(tx, params);
 }
 
+/// Ask each anycast resolver which of its sites is answering us (issue #6).
+/// One shot per run: the site follows our network path, not the query.
+fn spawn_site_probes(site_tx: &mpsc::UnboundedSender<(usize, sites::Site)>) {
+    for (index, resolver) in resolvers::active().iter().enumerate() {
+        let Some(probe) = resolver.probe else {
+            continue;
+        };
+        let site_tx = site_tx.clone();
+        let server = resolver.ip;
+        tokio::spawn(async move {
+            if let Some(site) = sites::discover(probe, server).await {
+                let _ = site_tx.send((index, site));
+            }
+        });
+    }
+}
+
 fn spawn_round(
     tx: &mpsc::UnboundedSender<QueryOutcome>,
     (domain, rtype, generation, indices): (String, RecordType, u64, Vec<usize>),
@@ -212,6 +238,15 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
         .begin_query()
         .ok_or_else(|| anyhow::anyhow!("empty domain"))?;
 
+    // Site probes run concurrently with the query round.
+    let mut probes = tokio::task::JoinSet::new();
+    for (index, resolver) in resolvers::active().iter().enumerate() {
+        if let Some(probe) = resolver.probe {
+            let server = resolver.ip;
+            probes.spawn(async move { (index, sites::discover(probe, server).await) });
+        }
+    }
+
     let mut tasks = tokio::task::JoinSet::new();
     for resolver_index in indices {
         let domain = domain.clone();
@@ -228,6 +263,10 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
     }
     while let Some(outcome) = tasks.join_next().await {
         app.apply(outcome?);
+    }
+    while let Some(probed) = probes.join_next().await {
+        let (index, site) = probed?;
+        app.sites[index] = site;
     }
 
     let summary = app.summary();
@@ -259,9 +298,15 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
             },
             _ => "??".into(),
         };
+        // Anycast resolvers that identified their answering site show it
+        // (→YUL) instead of the operator's configured home location.
+        let location = match &app.sites[i] {
+            Some(site) => format!("→{}", site.code),
+            None => resolver.location.clone(),
+        };
         println!(
             "{:<22} {:<8} {:<16} {line}",
-            resolver.name, resolver.location, resolver.ip
+            resolver.name, location, resolver.ip
         );
     }
 

--- a/src/resolvers.rs
+++ b/src/resolvers.rs
@@ -1,6 +1,8 @@
 use std::net::IpAddr;
 use std::sync::OnceLock;
 
+use crate::sites::SiteProbe;
+
 /// A resolver to query, either built-in or from the user's config file.
 #[derive(Debug, Clone)]
 pub struct Resolver {
@@ -9,6 +11,9 @@ pub struct Resolver {
     pub ip: IpAddr,
     /// (lat, lon) for the world-map view; None keeps the resolver off the map.
     pub coords: Option<(f64, f64)>,
+    /// How to ask this resolver which anycast site answered, if it supports
+    /// an identification query.
+    pub probe: Option<SiteProbe>,
 }
 
 /// The resolver list for this run. Set once at startup (after the config file
@@ -37,6 +42,7 @@ pub fn defaults() -> Vec<Resolver> {
             location: b.location.into(),
             ip: b.ip.parse().expect("built-in resolver IPs are valid"),
             coords: Some((b.lat, b.lon)),
+            probe: b.probe,
         })
         .collect()
 }
@@ -47,6 +53,7 @@ struct Builtin {
     ip: &'static str,
     lat: f64,
     lon: f64,
+    probe: Option<SiteProbe>,
 }
 
 /// Public DNS resolvers spread across regions. Anycast networks are marked as
@@ -65,6 +72,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "8.8.8.8",
         lat: 37.4,
         lon: -122.1,
+        probe: Some(SiteProbe::Google),
     },
     Builtin {
         name: "Cloudflare",
@@ -72,6 +80,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "1.1.1.1",
         lat: 37.8,
         lon: -122.4,
+        probe: Some(SiteProbe::Cloudflare),
     },
     Builtin {
         name: "Quad9",
@@ -79,6 +88,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "9.9.9.9",
         lat: 47.4,
         lon: 8.5,
+        probe: Some(SiteProbe::Quad9),
     },
     Builtin {
         name: "OpenDNS (Cisco)",
@@ -86,6 +96,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "208.67.222.222",
         lat: 33.9,
         lon: -118.2,
+        probe: Some(SiteProbe::OpenDns),
     },
     Builtin {
         name: "CleanBrowsing",
@@ -93,6 +104,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "185.228.168.9",
         lat: 33.4,
         lon: -112.0,
+        probe: Some(SiteProbe::ChIdServer),
     },
     // North America
     Builtin {
@@ -101,6 +113,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "4.2.2.2",
         lat: 39.7,
         lon: -105.0,
+        probe: None,
     },
     Builtin {
         name: "Lumen (Qwest)",
@@ -108,6 +121,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "205.171.3.66",
         lat: 40.4,
         lon: -104.0,
+        probe: None,
     },
     Builtin {
         name: "Hurricane Electric",
@@ -115,6 +129,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "74.82.42.42",
         lat: 37.6,
         lon: -122.0,
+        probe: None,
     },
     Builtin {
         name: "Neustar UltraDNS",
@@ -122,6 +137,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "64.6.64.6",
         lat: 39.0,
         lon: -77.5,
+        probe: Some(SiteProbe::ChIdServer),
     },
     Builtin {
         name: "Comodo Secure DNS",
@@ -129,6 +145,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "8.26.56.26",
         lat: 40.9,
         lon: -74.2,
+        probe: None,
     },
     Builtin {
         name: "FortiGuard",
@@ -136,6 +153,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "208.91.112.53",
         lat: 37.3,
         lon: -121.9,
+        probe: None,
     },
     Builtin {
         name: "CIRA Canadian Shield",
@@ -143,6 +161,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "149.112.121.10",
         lat: 45.4,
         lon: -75.7,
+        probe: None,
     },
     Builtin {
         name: "ControlD",
@@ -150,6 +169,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "76.76.2.0",
         lat: 43.7,
         lon: -79.4,
+        probe: None,
     },
     // Europe
     Builtin {
@@ -158,6 +178,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "86.54.11.100",
         lat: 50.1,
         lon: 14.4,
+        probe: None,
     },
     Builtin {
         name: "CZ.NIC ODVR",
@@ -165,6 +186,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "193.17.47.1",
         lat: 49.9,
         lon: 15.3,
+        probe: None,
     },
     Builtin {
         name: "AdGuard DNS",
@@ -172,6 +194,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "94.140.14.14",
         lat: 34.7,
         lon: 33.0,
+        probe: None,
     },
     Builtin {
         name: "Gcore DNS",
@@ -179,6 +202,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "95.85.95.85",
         lat: 49.6,
         lon: 6.1,
+        probe: None,
     },
     Builtin {
         name: "DNS.SB",
@@ -186,6 +210,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "185.222.222.222",
         lat: 50.1,
         lon: 8.7,
+        probe: None,
     },
     // Russia / Middle East
     Builtin {
@@ -194,6 +219,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "195.46.39.39",
         lat: 55.8,
         lon: 37.6,
+        probe: None,
     },
     Builtin {
         name: "Yandex DNS",
@@ -201,6 +227,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "77.88.8.8",
         lat: 55.6,
         lon: 37.9,
+        probe: None,
     },
     Builtin {
         name: "Comss.one",
@@ -208,6 +235,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "83.220.169.155",
         lat: 56.3,
         lon: 38.1,
+        probe: None,
     },
     Builtin {
         name: "Bezeq Intl",
@@ -215,6 +243,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "192.115.106.10",
         lat: 32.1,
         lon: 34.8,
+        probe: None,
     },
     // East Asia
     Builtin {
@@ -223,6 +252,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "114.114.114.114",
         lat: 32.1,
         lon: 118.8,
+        probe: None,
     },
     Builtin {
         name: "AliDNS",
@@ -230,6 +260,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "223.5.5.5",
         lat: 30.3,
         lon: 120.2,
+        probe: None,
     },
     Builtin {
         name: "DNSPod (Tencent)",
@@ -237,6 +268,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "119.29.29.29",
         lat: 22.5,
         lon: 114.1,
+        probe: None,
     },
     Builtin {
         name: "Baidu DNS",
@@ -244,6 +276,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "180.76.76.76",
         lat: 39.9,
         lon: 116.4,
+        probe: None,
     },
     Builtin {
         name: "CNNIC sDNS",
@@ -251,6 +284,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "1.2.4.8",
         lat: 40.5,
         lon: 116.9,
+        probe: None,
     },
     Builtin {
         name: "360 Secure DNS",
@@ -258,6 +292,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "101.226.4.6",
         lat: 31.2,
         lon: 121.5,
+        probe: None,
     },
     Builtin {
         name: "KT (Kornet)",
@@ -265,6 +300,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "168.126.63.1",
         lat: 37.6,
         lon: 127.0,
+        probe: None,
     },
     Builtin {
         name: "LG U+",
@@ -272,6 +308,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "164.124.101.2",
         lat: 36.5,
         lon: 127.9,
+        probe: None,
     },
     Builtin {
         name: "HiNet (Chunghwa)",
@@ -279,6 +316,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "168.95.1.1",
         lat: 25.0,
         lon: 121.6,
+        probe: None,
     },
     // Southern hemisphere
     Builtin {
@@ -287,6 +325,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "139.130.4.4",
         lat: -33.9,
         lon: 151.2,
+        probe: None,
     },
     Builtin {
         name: "SafeSurfer",
@@ -294,6 +333,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "104.197.28.121",
         lat: -36.8,
         lon: 174.8,
+        probe: None,
     },
     Builtin {
         name: "UOL",
@@ -301,6 +341,7 @@ const BUILTIN: &[Builtin] = &[
         ip: "200.221.11.100",
         lat: -23.5,
         lon: -46.6,
+        probe: None,
     },
 ];
 

--- a/src/sites.rs
+++ b/src/sites.rs
@@ -1,0 +1,559 @@
+//! Anycast site discovery: ask a resolver *which* of its sites answered.
+//!
+//! Large anycast networks expose an identification query — Quad9 answers
+//! `TXT id.server.on.quad9.net`, Cloudflare answers `CH TXT id.server`,
+//! Google reports its egress subnet, OpenDNS has `TXT debug.opendns.com`.
+//! The answer names the POP (usually by IATA airport code), telling you
+//! where your queries actually land instead of the operator's home region.
+//! See <https://github.com/514-labs/dnsglobe/issues/6>.
+
+use std::net::IpAddr;
+
+use crate::dns;
+
+/// Which identification query a resolver understands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiteProbe {
+    /// `IN TXT id.server.on.quad9.net` → `res120.qyul1.on.quad9.net`;
+    /// the second label carries the POP as `q<iata><n>`.
+    Quad9,
+    /// `CH TXT id.server` → `yul01` (IATA code plus a node number).
+    Cloudflare,
+    /// `IN TXT o-o.myaddr.l.google.com` returns the answering cluster's
+    /// egress IP; `IN TXT locations.publicdns.goog` maps egress prefixes to
+    /// IATA codes.
+    Google,
+    /// `IN TXT debug.opendns.com` → a `server r3.yyz` line; the last label
+    /// is the IATA code.
+    OpenDns,
+    /// Generic `CH TXT id.server` with a free-form site string (CleanBrowsing,
+    /// UltraDNS, …). Best-effort short token, usually not an airport code.
+    ChIdServer,
+}
+
+/// A discovered anycast site.
+#[derive(Debug, Clone)]
+pub struct Site {
+    /// Short display code, e.g. `YUL`. Uppercase, at most 7 chars.
+    pub code: String,
+    /// Map position when the code is a known IATA airport.
+    pub coords: Option<(f64, f64)>,
+}
+
+impl Site {
+    fn from_code(code: &str) -> Self {
+        let code: String = code.chars().take(7).collect::<String>().to_uppercase();
+        let coords = airport_coords(&code);
+        Site { code, coords }
+    }
+}
+
+/// Run one resolver's identification query. None means the probe failed or
+/// the answer was unparseable — the resolver keeps its configured location.
+pub async fn discover(probe: SiteProbe, server: IpAddr) -> Option<Site> {
+    match probe {
+        SiteProbe::Quad9 => {
+            let strings = dns::txt_strings(server, "id.server.on.quad9.net").await?;
+            parse_quad9(&strings)
+        }
+        SiteProbe::Cloudflare => {
+            let strings = dns::chaos_txt(server, "id.server").await?;
+            parse_cloudflare(&strings)
+        }
+        SiteProbe::Google => {
+            let myaddr = dns::txt_strings(server, "o-o.myaddr.l.google.com").await?;
+            let locations = dns::txt_strings(server, "locations.publicdns.goog").await?;
+            parse_google(&myaddr, &locations)
+        }
+        SiteProbe::OpenDns => {
+            let strings = dns::txt_strings(server, "debug.opendns.com").await?;
+            parse_opendns(&strings)
+        }
+        SiteProbe::ChIdServer => {
+            let strings = dns::chaos_txt(server, "id.server").await?;
+            parse_freeform(&strings)
+        }
+    }
+}
+
+/// `res120.qyul1.on.quad9.net` → the label starting with `q` names the POP:
+/// strip the `q` and the trailing node digits to get the IATA code.
+fn parse_quad9(strings: &[String]) -> Option<Site> {
+    let name = strings.first()?;
+    let pop = name.split('.').find(|label| {
+        label.len() >= 4
+            && label.starts_with('q')
+            && label[1..].chars().all(|c| c.is_ascii_alphanumeric())
+    })?;
+    let iata = pop[1..].trim_end_matches(|c: char| c.is_ascii_digit());
+    (iata.len() == 3).then(|| Site::from_code(iata))
+}
+
+/// `yul01` → leading letters are the IATA code.
+fn parse_cloudflare(strings: &[String]) -> Option<Site> {
+    let answer = strings.first()?.trim();
+    if answer.is_empty() || !answer.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    let iata: String = answer
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect();
+    (iata.len() == 3).then(|| Site::from_code(&iata))
+}
+
+/// `debug.opendns.com` answers several strings; the `server r3.yyz` line's
+/// last dot-label is the IATA code.
+fn parse_opendns(strings: &[String]) -> Option<Site> {
+    let server = strings
+        .iter()
+        .find_map(|s| s.strip_prefix("server "))?
+        .trim();
+    let iata = server.rsplit('.').next()?;
+    (iata.len() == 3 && iata.chars().all(|c| c.is_ascii_alphabetic()))
+        .then(|| Site::from_code(iata))
+}
+
+/// Match the egress IP from `o-o.myaddr.l.google.com` against the
+/// `locations.publicdns.goog` list of `<prefix> <code>` entries
+/// (longest prefix wins).
+fn parse_google(myaddr: &[String], locations: &[String]) -> Option<Site> {
+    // myaddr returns the egress IP plus informational strings like
+    // "edns0-client-subnet 203.0.113.0/24" — take the string that IS an IP.
+    let egress: IpAddr = myaddr.iter().find_map(|s| s.trim().parse().ok())?;
+
+    let mut best: Option<(u8, &str)> = None;
+    for entry in locations {
+        let mut parts = entry.split_whitespace();
+        let (Some(prefix), Some(code)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let Some((net, len)) = parse_cidr(prefix) else {
+            continue;
+        };
+        if cidr_contains(net, len, egress) && best.is_none_or(|(l, _)| len > l) {
+            best = Some((len, code));
+        }
+    }
+    let (_, code) = best?;
+    Some(Site::from_code(code))
+}
+
+/// Free-form `id.server` strings, e.g.
+/// `CleanBrowsing v1.6a - dns-edge-canada-toronto3` or `rcrsv4.cator1.ultradns`.
+/// Pull the most site-looking token: the last `-`/`.` segment that isn't a
+/// version or product name, digits stripped.
+fn parse_freeform(strings: &[String]) -> Option<Site> {
+    let answer = strings.first()?.trim();
+    if answer.is_empty() {
+        return None;
+    }
+    // Prefer what follows " - " when present, else the whole string.
+    let tail = answer.rsplit(" - ").next().unwrap_or(answer);
+    let token = tail
+        .split(['-', '.', ' '])
+        .map(|t| t.trim_end_matches(|c: char| c.is_ascii_digit()))
+        .rfind(|t| {
+            // Alphabetic, short enough to be a site name, and not a product
+            // suffix like "ultradns" — those carry no location.
+            (3..=12).contains(&t.len())
+                && t.chars().all(|c| c.is_ascii_alphabetic())
+                && !t.to_ascii_lowercase().contains("dns")
+        })?;
+    Some(Site::from_code(token))
+}
+
+/// Parse `a.b.c.d/len` or `x::/len`. IPv4 addresses are mapped into the
+/// IPv6 space so one u128 comparison covers both.
+fn parse_cidr(text: &str) -> Option<(u128, u8)> {
+    let (addr, len) = text.split_once('/')?;
+    let addr: IpAddr = addr.parse().ok()?;
+    let len: u8 = len.parse().ok()?;
+    let (bits, max) = ip_bits(addr);
+    (len <= max).then_some((bits, len + (128 - max)))
+}
+
+fn cidr_contains(net: u128, len: u8, ip: IpAddr) -> bool {
+    let (bits, _) = ip_bits(ip);
+    let mask = if len == 0 {
+        0
+    } else {
+        u128::MAX << (128 - len)
+    };
+    bits & mask == net & mask
+}
+
+/// An address as its IPv6-mapped bits plus the family's prefix-length span.
+fn ip_bits(ip: IpAddr) -> (u128, u8) {
+    match ip {
+        IpAddr::V4(v4) => (v4.to_ipv6_mapped().to_bits(), 32),
+        IpAddr::V6(v6) => (v6.to_bits(), 128),
+    }
+}
+
+fn airport_coords(code: &str) -> Option<(f64, f64)> {
+    AIRPORTS
+        .binary_search_by(|(c, _, _)| c.cmp(&code))
+        .ok()
+        .map(|i| (AIRPORTS[i].1, AIRPORTS[i].2))
+}
+
+/// (IATA code, lat, lon) for cities that host POPs of the probed networks
+/// (Cloudflare, Quad9/PCH, Google, OpenDNS). City-level accuracy is plenty
+/// for the braille world map. Sorted by code for binary search.
+const AIRPORTS: &[(&str, f64, f64)] = &[
+    ("ABJ", 5.3, -3.9),
+    ("ACC", 5.6, -0.2),
+    ("ADD", 9.0, 38.8),
+    ("ADL", -34.9, 138.5),
+    ("AKL", -37.0, 174.8),
+    ("ALA", 43.4, 77.0),
+    ("ALG", 36.7, 3.2),
+    ("AMD", 23.1, 72.6),
+    ("AMM", 31.7, 36.0),
+    ("AMS", 52.3, 4.8),
+    ("ANC", 61.2, -150.0),
+    ("ARN", 59.7, 17.9),
+    ("ATH", 37.9, 23.9),
+    ("ATL", 33.6, -84.4),
+    ("AUH", 24.4, 54.7),
+    ("AUS", 30.2, -97.7),
+    ("BAH", 26.3, 50.6),
+    ("BCN", 41.3, 2.1),
+    ("BEG", 44.8, 20.3),
+    ("BEL", -1.4, -48.5),
+    ("BER", 52.4, 13.5),
+    ("BEY", 33.8, 35.5),
+    ("BGI", 13.1, -59.5),
+    ("BGW", 33.3, 44.2),
+    ("BKK", 13.7, 100.7),
+    ("BLR", 13.2, 77.7),
+    ("BNA", 36.1, -86.7),
+    ("BNE", -27.4, 153.1),
+    ("BOD", 44.8, -0.7),
+    ("BOG", 4.7, -74.1),
+    ("BOM", 19.1, 72.9),
+    ("BOS", 42.4, -71.0),
+    ("BRU", 50.9, 4.5),
+    ("BSB", -15.9, -47.9),
+    ("BUD", 47.4, 19.3),
+    ("BUF", 42.9, -78.7),
+    ("CAI", 30.1, 31.4),
+    ("CAN", 23.4, 113.3),
+    ("CBR", -35.3, 149.2),
+    ("CCU", 22.7, 88.4),
+    ("CDG", 49.0, 2.5),
+    ("CEB", 10.3, 124.0),
+    ("CGK", -6.1, 106.7),
+    ("CHC", -43.5, 172.5),
+    ("CKG", 29.7, 106.6),
+    ("CLE", 41.4, -81.8),
+    ("CLT", 35.2, -80.9),
+    ("CMB", 7.2, 79.9),
+    ("CMH", 40.0, -83.0),
+    ("CMN", 33.4, -7.6),
+    ("CNX", 18.8, 99.0),
+    ("COK", 10.2, 76.4),
+    ("COR", -31.3, -64.2),
+    ("CPH", 55.6, 12.6),
+    ("CPT", -34.0, 18.6),
+    ("CTS", 42.8, 141.7),
+    ("CTU", 30.6, 104.0),
+    ("CUR", 12.2, -69.0),
+    ("CWB", -25.5, -49.2),
+    ("DAC", 23.8, 90.4),
+    ("DAR", -6.9, 39.2),
+    ("DEL", 28.6, 77.1),
+    ("DEN", 39.9, -104.7),
+    ("DFW", 32.9, -97.0),
+    ("DKR", 14.7, -17.4),
+    ("DLA", 4.0, 9.7),
+    ("DMM", 26.5, 49.8),
+    ("DOH", 25.3, 51.6),
+    ("DPS", -8.7, 115.2),
+    ("DTW", 42.2, -83.4),
+    ("DUB", 53.4, -6.3),
+    ("DUR", -29.6, 31.1),
+    ("DUS", 51.3, 6.8),
+    ("DXB", 25.3, 55.4),
+    ("EBB", 0.0, 32.4),
+    ("EDI", 55.9, -3.4),
+    ("EVN", 40.1, 44.4),
+    ("EWR", 40.7, -74.2),
+    ("EZE", -34.8, -58.5),
+    ("FCO", 41.8, 12.2),
+    ("FOR", -3.8, -38.5),
+    ("FRA", 50.0, 8.6),
+    ("FUK", 33.6, 130.5),
+    ("GDL", 20.5, -103.3),
+    ("GIG", -22.8, -43.2),
+    ("GOT", 57.7, 12.3),
+    ("GRU", -23.4, -46.5),
+    ("GUA", 14.6, -90.5),
+    ("GUM", 13.5, 144.8),
+    ("GVA", 46.2, 6.1),
+    ("GYD", 40.5, 50.1),
+    ("GYE", -2.2, -79.9),
+    ("HAM", 53.6, 10.0),
+    ("HAN", 21.2, 105.8),
+    ("HEL", 60.3, 24.9),
+    ("HGH", 30.2, 120.4),
+    ("HKG", 22.3, 113.9),
+    ("HND", 35.6, 139.8),
+    ("HNL", 21.3, -157.9),
+    ("HRE", -17.9, 31.1),
+    ("HYD", 17.2, 78.4),
+    ("IAD", 39.0, -77.5),
+    ("IAH", 30.0, -95.3),
+    ("ICN", 37.5, 126.4),
+    ("IND", 39.7, -86.3),
+    ("ISB", 33.6, 73.1),
+    ("IST", 41.0, 28.8),
+    ("JAX", 30.5, -81.7),
+    ("JED", 21.7, 39.2),
+    ("JFK", 40.6, -73.8),
+    ("JIB", 11.5, 43.2),
+    ("JNB", -26.1, 28.2),
+    ("KBP", 50.3, 30.9),
+    ("KEF", 64.0, -22.6),
+    ("KGL", -2.0, 30.1),
+    ("KHH", 22.6, 120.3),
+    ("KHI", 24.9, 67.2),
+    ("KIN", 18.0, -76.8),
+    ("KIV", 46.9, 28.9),
+    ("KIX", 34.4, 135.2),
+    ("KTM", 27.7, 85.4),
+    ("KUL", 2.7, 101.7),
+    ("KWI", 29.2, 48.0),
+    ("LAD", -8.9, 13.2),
+    ("LAS", 36.1, -115.2),
+    ("LAX", 33.9, -118.4),
+    ("LED", 59.8, 30.3),
+    ("LHE", 31.5, 74.4),
+    ("LHR", 51.5, -0.5),
+    ("LIM", -12.0, -77.1),
+    ("LIS", 38.8, -9.1),
+    ("LOS", 6.6, 3.3),
+    ("LPA", 27.9, -15.4),
+    ("LPB", -16.5, -68.2),
+    ("LUN", -15.3, 28.5),
+    ("LUX", 49.6, 6.2),
+    ("LYS", 45.7, 5.1),
+    ("MAA", 13.0, 80.2),
+    ("MAD", 40.5, -3.6),
+    ("MAN", 53.4, -2.3),
+    ("MAO", -3.0, -60.0),
+    ("MBA", -4.0, 39.6),
+    ("MCI", 39.3, -94.7),
+    ("MCO", 28.4, -81.3),
+    ("MCT", 23.6, 58.3),
+    ("MDE", 6.2, -75.6),
+    ("MEL", -37.7, 144.8),
+    ("MEM", 35.0, -90.0),
+    ("MEX", 19.4, -99.1),
+    ("MFM", 22.1, 113.6),
+    ("MIA", 25.8, -80.3),
+    ("MNL", 14.5, 121.0),
+    ("MPM", -25.9, 32.6),
+    ("MRS", 43.4, 5.2),
+    ("MRU", -20.4, 57.7),
+    ("MSP", 44.9, -93.2),
+    ("MSY", 30.0, -90.3),
+    ("MTY", 25.8, -100.1),
+    ("MUC", 48.4, 11.8),
+    ("MVD", -34.8, -56.0),
+    ("MXP", 45.6, 8.7),
+    ("NBO", -1.3, 36.9),
+    ("NOU", -22.0, 166.2),
+    ("NRT", 35.8, 140.4),
+    ("OKA", 26.2, 127.6),
+    ("OKC", 35.4, -97.6),
+    ("OMA", 41.3, -95.9),
+    ("ORD", 42.0, -87.9),
+    ("OSL", 60.2, 11.1),
+    ("OTP", 44.6, 26.1),
+    ("PDX", 45.6, -122.6),
+    ("PER", -31.9, 116.0),
+    ("PHL", 39.9, -75.2),
+    ("PHX", 33.4, -112.0),
+    ("PIT", 40.5, -80.2),
+    ("PMO", 38.2, 13.1),
+    ("PNH", 11.5, 104.9),
+    ("POA", -30.0, -51.2),
+    ("POM", -9.4, 147.2),
+    ("POS", 10.6, -61.4),
+    ("PPT", -17.6, -149.6),
+    ("PRG", 50.1, 14.3),
+    ("PTY", 9.1, -79.4),
+    ("PVG", 31.1, 121.8),
+    ("QRO", 20.6, -100.4),
+    ("RDU", 35.9, -78.8),
+    ("REC", -8.1, -34.9),
+    ("RGN", 16.9, 96.1),
+    ("RIC", 37.5, -77.3),
+    ("RIX", 56.9, 24.0),
+    ("RUH", 25.0, 46.7),
+    ("SAN", 32.7, -117.2),
+    ("SAT", 29.5, -98.5),
+    ("SCL", -33.4, -70.8),
+    ("SDQ", 18.4, -69.7),
+    ("SEA", 47.4, -122.3),
+    ("SFO", 37.6, -122.4),
+    ("SGN", 10.8, 106.7),
+    ("SIN", 1.4, 104.0),
+    ("SJC", 37.4, -121.9),
+    ("SJO", 10.0, -84.2),
+    ("SJU", 18.4, -66.0),
+    ("SKG", 40.5, 23.0),
+    ("SKP", 42.0, 21.6),
+    ("SLC", 40.8, -112.0),
+    ("SMF", 38.7, -121.6),
+    ("SOF", 42.7, 23.4),
+    ("SSA", -12.9, -38.3),
+    ("STL", 38.7, -90.4),
+    ("STR", 48.7, 9.2),
+    ("SUB", -7.4, 112.8),
+    ("SUV", -18.0, 178.4),
+    ("SYD", -33.9, 151.2),
+    ("SZX", 22.6, 113.8),
+    ("TAS", 41.3, 69.3),
+    ("TBS", 41.7, 45.0),
+    ("TGU", 14.1, -87.2),
+    ("TIA", 41.4, 19.7),
+    ("TLH", 30.4, -84.4),
+    ("TLL", 59.4, 24.8),
+    ("TLV", 32.0, 34.9),
+    ("TNR", -18.8, 47.5),
+    ("TPA", 28.0, -82.5),
+    ("TPE", 25.1, 121.2),
+    ("TSN", 39.1, 117.3),
+    ("TUN", 36.9, 10.2),
+    ("UIO", -0.1, -78.4),
+    ("ULN", 47.8, 106.8),
+    ("VIE", 48.1, 16.6),
+    ("VNO", 54.6, 25.3),
+    ("VTE", 18.0, 102.6),
+    ("WAW", 52.2, 21.0),
+    ("WLG", -41.3, 174.8),
+    ("WUH", 30.8, 114.2),
+    ("XIY", 34.4, 108.8),
+    ("YHZ", 44.9, -63.5),
+    ("YOW", 45.3, -75.7),
+    ("YUL", 45.5, -73.7),
+    ("YVR", 49.2, -123.2),
+    ("YWG", 49.9, -97.2),
+    ("YYC", 51.1, -114.0),
+    ("YYZ", 43.7, -79.6),
+    ("ZAG", 45.7, 16.1),
+    ("ZRH", 47.5, 8.6),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn airports_are_sorted_unique_and_in_range() {
+        for pair in AIRPORTS.windows(2) {
+            assert!(pair[0].0 < pair[1].0, "{} out of order", pair[1].0);
+        }
+        for &(code, lat, lon) in AIRPORTS {
+            assert_eq!(code.len(), 3);
+            assert!(code.chars().all(|c| c.is_ascii_uppercase()));
+            assert!((-90.0..=90.0).contains(&lat), "{code} lat");
+            assert!((-180.0..=180.0).contains(&lon), "{code} lon");
+        }
+    }
+
+    #[test]
+    fn quad9_pop_name_yields_iata() {
+        let site = parse_quad9(&strings(&["res120.qyul1.on.quad9.net"])).unwrap();
+        assert_eq!(site.code, "YUL");
+        assert!(site.coords.is_some());
+        // Older PCH-hosted form.
+        let site = parse_quad9(&strings(&["res100.qzrh2.rrdns.pch.net"])).unwrap();
+        assert_eq!(site.code, "ZRH");
+        assert!(parse_quad9(&strings(&["unexpected"])).is_none());
+    }
+
+    #[test]
+    fn cloudflare_colo_yields_iata() {
+        let site = parse_cloudflare(&strings(&["yul01"])).unwrap();
+        assert_eq!(site.code, "YUL");
+        assert_eq!(site.coords, Some((45.5, -73.7)));
+        assert!(parse_cloudflare(&strings(&["not-a-colo"])).is_none());
+    }
+
+    #[test]
+    fn opendns_server_line_yields_iata() {
+        let answer = strings(&[
+            "server r3.yyz",
+            "flags 22040030 0 70 4001800000000000",
+            "originid 0",
+        ]);
+        let site = parse_opendns(&answer).unwrap();
+        assert_eq!(site.code, "YYZ");
+        assert!(site.coords.is_some());
+        assert!(parse_opendns(&strings(&["flags 0"])).is_none());
+    }
+
+    #[test]
+    fn google_longest_prefix_wins() {
+        let myaddr = strings(&["edns0-client-subnet 203.0.113.0/24", "34.64.1.9"]);
+        let locations = strings(&[
+            "34.64.0.0/16 xxx ",
+            "34.64.1.0/24 icn ",
+            "74.114.28.64/26 bkk ",
+        ]);
+        let site = parse_google(&myaddr, &locations).unwrap();
+        assert_eq!(site.code, "ICN");
+        assert!(site.coords.is_some());
+    }
+
+    #[test]
+    fn google_matches_ipv6_prefixes() {
+        let myaddr = strings(&["2404:6800:4008:c06::1"]);
+        let locations = strings(&["2404:6800:4008::/48 tpe ", "192.0.2.0/24 xxx "]);
+        let site = parse_google(&myaddr, &locations).unwrap();
+        assert_eq!(site.code, "TPE");
+    }
+
+    #[test]
+    fn google_without_match_is_none() {
+        let myaddr = strings(&["198.51.100.7"]);
+        let locations = strings(&["34.64.1.0/24 icn "]);
+        assert!(parse_google(&myaddr, &locations).is_none());
+    }
+
+    #[test]
+    fn freeform_extracts_a_site_token() {
+        let site = parse_freeform(&strings(&[
+            "CleanBrowsing v1.6a - dns-edge-canada-toronto3",
+        ]))
+        .unwrap();
+        assert_eq!(site.code, "TORONTO");
+        assert!(site.coords.is_none());
+
+        let site = parse_freeform(&strings(&["rcrsv4.cator1.ultradns"])).unwrap();
+        assert_eq!(site.code, "CATOR");
+
+        assert!(parse_freeform(&strings(&[""])).is_none());
+    }
+
+    #[test]
+    fn cidr_matching_handles_edge_lengths() {
+        let (net, len) = parse_cidr("0.0.0.0/0").unwrap();
+        assert!(cidr_contains(net, len, "203.0.113.9".parse().unwrap()));
+        let (net, len) = parse_cidr("203.0.113.9/32").unwrap();
+        assert!(cidr_contains(net, len, "203.0.113.9".parse().unwrap()));
+        assert!(!cidr_contains(net, len, "203.0.113.8".parse().unwrap()));
+        // A v4 prefix must not swallow v6 addresses.
+        let (net, len) = parse_cidr("0.0.0.0/0").unwrap();
+        assert!(!cidr_contains(net, len, "2001:db8::1".parse().unwrap()));
+        assert!(parse_cidr("34.64.0.0/33").is_none());
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,9 +14,9 @@ use crate::dns::QueryResult;
 use crate::resolvers;
 
 const ACCENT: Color = Color::Cyan;
-/// Table needs ~102 cols; only show the map when there's room for both.
-const MIN_WIDTH_FOR_MAP: u16 = 156;
-const TABLE_WIDTH: u16 = 102;
+/// Table needs ~103 cols; only show the map when there's room for both.
+const MIN_WIDTH_FOR_MAP: u16 = 157;
+const TABLE_WIDTH: u16 = 103;
 /// Dot/status color for a cache serving an answer past its own TTL.
 const STALE_COLOR: Color = Color::LightRed;
 /// Dot/status color for "refetched but upstream still serves the old data".
@@ -307,12 +307,21 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                     }
                 }
             };
-            Row::new(vec![
-                Cell::from(resolver.name.as_str()),
-                Cell::from(Span::styled(
+            // A discovered anycast site ("→YUL") replaces the configured
+            // home location: it names the POP actually answering us.
+            let loc_cell = match &app.sites[i] {
+                Some(site) => Cell::from(Span::styled(
+                    format!("→{}", site.code),
+                    Style::new().fg(ACCENT),
+                )),
+                None => Cell::from(Span::styled(
                     resolver.location.as_str(),
                     Style::new().fg(Color::DarkGray),
                 )),
+            };
+            Row::new(vec![
+                Cell::from(resolver.name.as_str()),
+                loc_cell,
                 Cell::from(Span::styled(
                     resolver.ip.to_string(),
                     Style::new().fg(Color::DarkGray),
@@ -329,7 +338,7 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
         rows,
         [
             Constraint::Length(21),
-            Constraint::Length(7),
+            Constraint::Length(8),
             Constraint::Length(15),
             Constraint::Length(7),
             Constraint::Length(6),
@@ -376,9 +385,11 @@ fn draw_map(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, are
                 resolution: MapResolution::High,
             });
             let now = Instant::now();
-            for (i, (resolver, state)) in resolvers::active().iter().zip(&app.rows).enumerate() {
-                let Some((lat, lon)) = resolver.coords else {
-                    continue; // config resolver without map coordinates
+            for (i, state) in app.rows.iter().enumerate() {
+                // Discovered anycast site position when known, else the
+                // configured one; None keeps the resolver off the map.
+                let Some((lat, lon)) = app.effective_coords(i) else {
+                    continue;
                 };
                 let color = match state {
                     RowState::Idle => Color::DarkGray,


### PR DESCRIPTION
Closes #6.

Large anycast resolvers can tell you which of their sites your queries actually reach. This PR asks them, per @johnhtodd's suggestion, and surfaces the answer in the table and on the map.

## Identification queries used

| Resolver | Query | Example answer | Parsed |
|---|---|---|---|
| Quad9 | `IN TXT id.server.on.quad9.net` | `res120.qyul1.on.quad9.net` | `YUL` |
| Cloudflare | `CH TXT id.server` | `yul01` | `YUL` |
| Google | `IN TXT o-o.myaddr.l.google.com` + `IN TXT locations.publicdns.goog` | egress IP matched against the prefix→site list (longest prefix wins) | `YUL` |
| OpenDNS | `IN TXT debug.opendns.com` | `server r3.yyz` | `YYZ` |
| CleanBrowsing | `CH TXT id.server` | `CleanBrowsing v1.6a - dns-edge-newyork1` | `NEWYORK` |
| Neustar UltraDNS | `CH TXT id.server` | `rcrsv4.usnyc1.ultradns` | `USNYC` |

## What it looks like

- The **Loc column** shows the discovered site as `→YUL` (accent-colored) instead of the operator's home region; resolvers without a working probe keep their configured location.
- The **map dot moves** to the POP actually serving you, via an embedded IATA→lat/lon table (~230 POP cities of these networks). Unknown codes still display in the table; the dot just stays put.
- Works in both the TUI and `--once` mode.

Verified live from Montréal:

```
Google Public DNS      →YUL     8.8.8.8          OK         60ms  ...
Cloudflare             →YUL     1.1.1.1          OK         28ms  ...
Quad9                  →YUL     9.9.9.9          OK         24ms  ...
OpenDNS (Cisco)        →YYZ     208.67.222.222   OK         55ms  ...
CleanBrowsing          →NEWYORK 185.228.168.9    OK         57ms  ...
Neustar UltraDNS       →USNYC   64.6.64.6        OK         50ms  ...
```

## Implementation notes

- Probes run **once per session** (concurrently with the first query round): the answering site follows your network path, not the queried domain. A failed probe just leaves the configured location — no error states.
- CHAOS-class TXT isn't expressible through hickory's high-level resolver, so `id.server` queries are hand-rolled over UDP with hickory-proto (response ID checked, connected socket; answers are tiny so no truncation handling needed).
- The IN-class probes reuse the same resolver configuration as regular measurement queries (no cache, single attempt, EDNS0, TCP retry on truncation) — Google's `locations.publicdns.goog` answer is ~4 KB, so the truncation retry matters there.
- All parsers are pure functions with unit tests, including longest-prefix matching for both IPv4 and IPv6 Google egress ranges.
- A fun side effect observed while testing from a hotel network that intercepts UDP/53: the probes fail or name the interceptor rather than a real POP — an honest signal that your queries aren't reaching the resolver you think.

Possible follow-ups (out of scope here): a config-file knob to attach a probe to custom resolvers, and periodic re-probing for long-running watches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)