### PR TITLE
Parse arguments with clap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Argument parsing via clap: `--help` and `--version` now work, invalid
+  arguments get proper error messages, and an optional record-type
+  positional (`dnsglobe example.com TXT`) sets the starting record type in
+  TUI mode too — previously it was only honored with `--once`. The long
+  `--help` also documents `$DNSGLOBE_CONFIG` and the config-file syntax.
 - Anycast site geolocation: large anycast resolvers (Quad9, Cloudflare,
   Google, OpenDNS, CleanBrowsing, Neustar UltraDNS) are asked which POP is
   answering via identification queries (`id.server` CH TXT and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +215,52 @@ dependencies = [
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -412,6 +508,7 @@ name = "dnsglobe"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "clap",
  "crossterm",
  "futures",
  "hickory-resolver",
@@ -927,6 +1024,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1329,12 @@ dependencies = [
  "critical-section",
  "portable-atomic",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ordered-float"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0"
+clap = { version = "4.6", features = ["derive"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 futures = "0.3"
 hickory-resolver = "0.26"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Run:
 ```sh
 dnsglobe                            # start empty, type a domain
 dnsglobe example.com                # query immediately and watch
-dnsglobe --once example.com TXT    # no TUI: print results, exit (for scripts)
+dnsglobe example.com TXT            # same, starting on TXT records
+dnsglobe --once example.com TXT     # no TUI: print results, exit (for scripts)
 ```
 
 ### Keys

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use clap::Parser;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
 use futures::StreamExt;
 use hickory_resolver::proto::rr::RecordType;
@@ -18,39 +19,90 @@ use tokio::sync::mpsc;
 use app::{App, POLL_INTERVAL};
 use dns::QueryOutcome;
 
+const CONFIG_HELP: &str = "\
+Configuration:
+  An optional TOML file adds resolvers to the built-in list, or replaces it
+  entirely (replace = true). Looked up at $DNSGLOBE_CONFIG (error if the file
+  is missing), else $XDG_CONFIG_HOME/dnsglobe/config.toml, else
+  ~/.config/dnsglobe/config.toml.
+
+  # replace = true       # use only the resolvers below, drop the built-ins
+  [[resolvers]]
+  name = \"Corp DNS\"      # required
+  ip = \"10.0.0.53\"       # required, IPv4 or IPv6
+  location = \"HQ\"        # optional; shown in the Loc column
+  lat = 40.7             # optional map position;
+  lon = -74.0            # give both or neither";
+
+/// Global DNS propagation checker TUI — watch a DNS record propagate across
+/// public resolvers worldwide, on a world map in your terminal.
+#[derive(Parser)]
+#[command(
+    version,
+    after_help = "Configuration: custom resolvers via $DNSGLOBE_CONFIG or \
+                  ~/.config/dnsglobe/config.toml (see --help for the syntax)",
+    after_long_help = CONFIG_HELP
+)]
+struct Cli {
+    /// Domain to start checking immediately
+    domain: Option<String>,
+
+    /// Record type to query: A, AAAA, CNAME, MX, NS, TXT or SOA [default: A]
+    #[arg(value_parser = parse_record_type)]
+    record_type: Option<RecordType>,
+
+    /// Run a single check, print a plain-text table, and exit (no TTY needed)
+    #[arg(long, requires = "domain")]
+    once: bool,
+}
+
+fn parse_record_type(s: &str) -> Result<RecordType, String> {
+    RecordType::from_str(&s.to_uppercase())
+        .ok()
+        .filter(|rtype| app::RECORD_TYPES.contains(rtype))
+        .ok_or_else(|| {
+            let supported: Vec<String> = app::RECORD_TYPES.iter().map(|t| t.to_string()).collect();
+            format!(
+                "unsupported record type (expected one of {})",
+                supported.join(", ")
+            )
+        })
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
     // Fail on a broken config before the terminal enters raw mode, so the
     // error prints normally.
     resolvers::init(config::load()?);
 
-    let mut args = std::env::args().skip(1).peekable();
-
-    // `--once <domain> [type]` runs a single check and prints plain text —
-    // handy for scripts and for testing without a TTY.
-    if args.peek().map(String::as_str) == Some("--once") {
-        args.next();
-        let domain = args
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("usage: dnsglobe --once <domain> [type]"))?;
-        let rtype = match args.next() {
-            Some(t) => RecordType::from_str(&t.to_uppercase())
-                .map_err(|_| anyhow::anyhow!("unknown record type: {t}"))?,
-            None => RecordType::A,
-        };
-        return run_once(domain, rtype).await;
+    // `--once` runs a single check and prints plain text — handy for scripts
+    // and for testing without a TTY.
+    if cli.once {
+        let domain = cli.domain.expect("clap enforces `requires`");
+        return run_once(domain, cli.record_type.unwrap_or(RecordType::A)).await;
     }
 
-    let initial_domain = args.next().unwrap_or_default();
     let terminal = ratatui::init();
-    let result = run_tui(terminal, initial_domain).await;
+    let result = run_tui(terminal, cli.domain.unwrap_or_default(), cli.record_type).await;
     ratatui::restore();
     result
 }
 
-async fn run_tui(mut terminal: ratatui::DefaultTerminal, initial_domain: String) -> Result<()> {
+async fn run_tui(
+    mut terminal: ratatui::DefaultTerminal,
+    initial_domain: String,
+    initial_rtype: Option<RecordType>,
+) -> Result<()> {
     let auto_query = !initial_domain.is_empty();
     let mut app = App::new(initial_domain);
+    if let Some(rtype) = initial_rtype {
+        app.rtype_idx = app::RECORD_TYPES
+            .iter()
+            .position(|t| *t == rtype)
+            .unwrap_or(0);
+    }
 
     // Worker tasks send results here; keeping `tx` alive in this scope means
     // `rx.recv()` never observes a closed channel.


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `std::env::args()` parsing with [clap](https://docs.rs/clap) (derive), so `dnsglobe --help` and `--version` work.

- CLI is now `dnsglobe [OPTIONS] [DOMAIN] [RECORD_TYPE]` with a `--once` flag — all existing invocations (`dnsglobe`, `dnsglobe example.com`, `dnsglobe --once example.com TXT`) behave exactly as before
- The record-type positional is validated against the supported types (A, AAAA, CNAME, MX, NS, TXT, SOA) with a helpful error — previously `--once foo PTR` silently queried A
- The record type is now also honored in TUI mode: `dnsglobe example.com TXT` starts the TUI on TXT
- `--once` without a domain gets a proper usage error via clap's `requires`
- Long `--help` documents `$DNSGLOBE_CONFIG`, the config lookup order, and the config-file TOML syntax; short `-h` ends with a one-line pointer
- README usage block and CHANGELOG updated

## Test plan

- `cargo test` (39 passed), `cargo clippy` clean, `cargo fmt --check` clean
- Manually exercised `-h`, `--help`, `--version`, `--once example.com TXT`, lowercase record types, `--once` without domain (usage error), and an unsupported record type (validation error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)