### PR TITLE
Word and line cursor motions in the domain input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Word and line cursor motions in the domain input: Option/Alt+←/→ (or
+  Ctrl+←/→, or Alt+B/F) moves the cursor by one dot-separated label;
+  Cmd+←/→ (or Home/End, or Ctrl+A/E) jumps to the start/end of the input.
+  Cmd is reported via the kitty keyboard protocol, enabled when the
+  terminal supports it. ([#17](https://github.com/514-labs/dnsglobe/pull/17))
 - Argument parsing via clap: `--help` and `--version` now work, invalid
   arguments get proper error messages, and an optional record-type
   positional (`dnsglobe example.com TXT`) sets the starting record type in

--- a/src/app.rs
+++ b/src/app.rs
@@ -241,6 +241,30 @@ impl App {
         self.cursor = (self.cursor + 1).min(self.domain.len());
     }
 
+    /// Jump to the start of the current dot-separated label, or of the
+    /// previous one when already at a label boundary.
+    pub fn move_cursor_word_left(&mut self) {
+        let bytes = self.domain.as_bytes();
+        while self.cursor > 0 && bytes[self.cursor - 1] == b'.' {
+            self.cursor -= 1;
+        }
+        while self.cursor > 0 && bytes[self.cursor - 1] != b'.' {
+            self.cursor -= 1;
+        }
+    }
+
+    /// Jump past the end of the current dot-separated label, or of the next
+    /// one when already at a label boundary.
+    pub fn move_cursor_word_right(&mut self) {
+        let bytes = self.domain.as_bytes();
+        while self.cursor < bytes.len() && bytes[self.cursor] == b'.' {
+            self.cursor += 1;
+        }
+        while self.cursor < bytes.len() && bytes[self.cursor] != b'.' {
+            self.cursor += 1;
+        }
+    }
+
     pub fn clear_domain(&mut self) {
         self.domain.clear();
         self.cursor = 0;
@@ -681,6 +705,48 @@ mod tests {
             min_ttl,
             at: now - Duration::from_secs(ago),
         }
+    }
+
+    #[test]
+    fn word_left_jumps_to_label_starts() {
+        let mut app = App::new("api.example.com".into());
+        app.cursor = app.domain.len();
+        let stops: Vec<usize> = std::iter::from_fn(|| {
+            app.move_cursor_word_left();
+            Some(app.cursor)
+        })
+        .take(4)
+        .collect();
+        // "api.example.com": label starts at 12 ("com"), 4 ("example"),
+        // 0 ("api"), then stays put.
+        assert_eq!(stops, vec![12, 4, 0, 0]);
+    }
+
+    #[test]
+    fn word_right_jumps_to_label_ends() {
+        let mut app = App::new("api.example.com".into());
+        app.cursor = 0;
+        let stops: Vec<usize> = std::iter::from_fn(|| {
+            app.move_cursor_word_right();
+            Some(app.cursor)
+        })
+        .take(4)
+        .collect();
+        assert_eq!(stops, vec![3, 11, 15, 15]);
+    }
+
+    #[test]
+    fn word_motion_skips_consecutive_dots() {
+        let mut app = App::new("a..b".into());
+        app.cursor = 4;
+        app.move_cursor_word_left();
+        assert_eq!(app.cursor, 3); // start of "b"
+        app.move_cursor_word_left();
+        assert_eq!(app.cursor, 0); // past both dots to start of "a"
+        app.move_cursor_word_right();
+        assert_eq!(app.cursor, 1); // end of "a"
+        app.move_cursor_word_right();
+        assert_eq!(app.cursor, 4); // past both dots to end of "b"
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use clap::Parser;
-use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
 use futures::StreamExt;
 use hickory_resolver::proto::rr::RecordType;
 use tokio::sync::mpsc;
@@ -85,7 +85,22 @@ async fn main() -> Result<()> {
     }
 
     let terminal = ratatui::init();
+    // Ask for the kitty keyboard protocol where supported (iTerm2, kitty,
+    // Ghostty, WezTerm, ...): it's the only way terminals report Cmd (SUPER)
+    // and reliably distinguish Option-modified arrows for input navigation.
+    let enhanced_keys = crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false);
+    if enhanced_keys {
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            event::PushKeyboardEnhancementFlags(
+                event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+            )
+        );
+    }
     let result = run_tui(terminal, cli.domain.unwrap_or_default(), cli.record_type).await;
+    if enhanced_keys {
+        let _ = crossterm::execute!(std::io::stdout(), event::PopKeyboardEnhancementFlags);
+    }
     ratatui::restore();
     result
 }
@@ -203,10 +218,33 @@ fn handle_key(
         KeyCode::Enter => spawn_queries(app, tx),
         KeyCode::Tab => app.cycle_record_type(true),
         KeyCode::BackTab => app.cycle_record_type(false),
+        // Cmd+←/→ on macOS (reported as SUPER under the kitty keyboard
+        // protocol): jump to the start/end of the input, like Home/End.
+        KeyCode::Left if modifiers.contains(KeyModifiers::SUPER) => app.cursor = 0,
+        KeyCode::Right if modifiers.contains(KeyModifiers::SUPER) => {
+            app.cursor = app.domain.len();
+        }
+        // Option+←/→ on macOS (ALT), Ctrl+←/→ on Windows/Linux: move by one
+        // dot-separated label.
+        KeyCode::Left if modifiers.intersects(KeyModifiers::ALT | KeyModifiers::CONTROL) => {
+            app.move_cursor_word_left();
+        }
+        KeyCode::Right if modifiers.intersects(KeyModifiers::ALT | KeyModifiers::CONTROL) => {
+            app.move_cursor_word_right();
+        }
         KeyCode::Left => app.move_cursor_left(),
         KeyCode::Right => app.move_cursor_right(),
         KeyCode::Home => app.cursor = 0,
         KeyCode::End => app.cursor = app.domain.len(),
+        // Terminal.app (and iTerm2's default profile) send Esc-b / Esc-f for
+        // Option+←/→ — the readline word-motion sequences.
+        KeyCode::Char('b') if modifiers.contains(KeyModifiers::ALT) => app.move_cursor_word_left(),
+        KeyCode::Char('f') if modifiers.contains(KeyModifiers::ALT) => app.move_cursor_word_right(),
+        // Readline line motions, for terminals that don't forward Cmd at all.
+        KeyCode::Char('a') if modifiers.contains(KeyModifiers::CONTROL) => app.cursor = 0,
+        KeyCode::Char('e') if modifiers.contains(KeyModifiers::CONTROL) => {
+            app.cursor = app.domain.len();
+        }
         KeyCode::Up => app.scroll = app.scroll.saturating_sub(1),
         KeyCode::Down => app.scroll += 1, // clamped during draw
         KeyCode::PageUp => app.scroll = app.scroll.saturating_sub(10),
@@ -214,7 +252,8 @@ fn handle_key(
         KeyCode::Backspace => app.backspace(),
         KeyCode::Delete => app.delete(),
         KeyCode::Char(c)
-            if !modifiers.contains(KeyModifiers::CONTROL)
+            if !modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
                 && (c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_')) =>
         {
             app.insert_char(c.to_ascii_lowercase());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -499,7 +499,7 @@ fn draw_footer(
         ));
     }
     let keys = Line::from(Span::styled(
-        " type to edit · ←/→ move cursor · Enter query+watch · Ctrl+R watch on/off · Ctrl+S sort · Tab record type · ↑/↓ scroll · Esc quit",
+        " type to edit · ←/→ move cursor (⌥/Ctrl word, ⌘/Home/End ends) · Enter query+watch · Ctrl+R watch on/off · Ctrl+S sort · Tab record type · ↑/↓ scroll · Esc quit",
         Style::new().fg(Color::DarkGray),
     ));
     if let Some(advisory) = advisory {


### PR DESCRIPTION
## What

Adds word-wise and line-wise cursor navigation to the domain input field:

| Action | macOS | Windows/Linux | Universal fallback |
|---|---|---|---|
| Word left/right | Option+←/→ | Ctrl+←/→ | Alt+B / Alt+F |
| Start/end of input | Cmd+←/→ | Home / End | Ctrl+A / Ctrl+E |

A "word" is a dot-separated label: in `api.example.com`, Option+← from the end stops before `com`, then `example`, then `api`. Runs of consecutive dots are skipped in one jump.

## How

- `App::move_cursor_word_left/right` implement the label-wise motion (input is ASCII-only, so byte indexing is safe).
- Option+arrows arrive differently per terminal: modern terminals send Alt-modified arrows, Terminal.app's default profile sends readline `Esc b`/`Esc f` — both are bound.
- Cmd (SUPER) is only reported under the kitty keyboard protocol, so `main()` probes with `supports_keyboard_enhancement()` and pushes `DISAMBIGUATE_ESCAPE_CODES` when available (popped on exit). Terminals that don't forward Cmd fall back to Home/End and Ctrl+A/E.
- The character-insert arm now rejects Alt/Cmd-modified letters so word-motion chords can't leak literal `b`/`f` into the domain.
- Footer hint updated to mention the new motions.

## Testing

- 3 new unit tests for label starts, label ends, and consecutive-dot skipping (42 total pass; clippy and fmt clean).
- Verified end-to-end by driving the built TUI through a PTY (`expect`): typed `api.example.com`, exercised Esc-b, Ctrl+←, Ctrl+A, Ctrl+E, and Alt+→ while inserting marker characters — the input rendered as `x3-api-x5.x2-example.x1-com-x4`, proving each motion landed the cursor at the right spot, and Esc still quits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)