### PR TITLE
Add AGENTS.md with the feature workflow, pointed to by CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# Working on dnsglobe
+
+dnsglobe is a Rust TUI (ratatui + crossterm + hickory-resolver) that watches
+a DNS record propagate across public resolvers worldwide. This file describes
+the process for building a new feature; it applies to any coding agent or
+human contributor.
+
+## Module map
+
+| File | Owns |
+|---|---|
+| `src/main.rs` | CLI (clap), event loop, key handling, `--once` mode |
+| `src/app.rs` | `App` state, input editing, answer grouping, TTL verdicts |
+| `src/ui.rs` | All rendering: map, table, gauge, footer |
+| `src/dns.rs` | Resolver queries and error mapping |
+| `src/resolvers.rs` | Built-in resolver list |
+| `src/config.rs` | TOML config file (custom resolvers) |
+| `src/sites.rs` | Anycast POP discovery (id.server probes, IATA codes) |
+
+Keep logic in `app.rs` (testable, no I/O) and rendering in `ui.rs`. Key
+bindings live in `handle_key` in `main.rs` and should call one-line `App`
+methods rather than mutating state inline.
+
+## Process for a new feature
+
+1. **Branch off `main`.** Direct pushes to `main` are blocked by an org
+   ruleset — all changes land via PR.
+
+2. **Implement, with state and rendering separated.** New behavior goes in
+   `App` methods; `ui.rs` only reads state. Comments explain *why* (protocol
+   quirks, terminal compatibility, DNS semantics), not what the code does —
+   match the density and tone of the surrounding code.
+
+3. **Unit-test the logic.** Tests live in `#[cfg(test)] mod tests` at the
+   bottom of the same file. Anything in `app.rs` should be testable without
+   a terminal or network.
+
+4. **Run the quality gates locally** — CI enforces exactly these on every PR:
+
+   ```sh
+   cargo fmt --check
+   cargo clippy --all-targets -- -D warnings
+   cargo test
+   ```
+
+5. **Verify end-to-end, not just with tests.**
+   - Query/output logic: `cargo run -- example.com --once` prints a plain
+     table without needing a TTY.
+   - TUI behavior (key bindings, rendering, watch mode): drive the real
+     binary through a PTY, e.g. with `expect` or tmux, and assert on the
+     rendered output. Two PTY gotchas: an `expect`-spawned PTY starts with
+     zero size (fix with `stty rows 30 columns 110 < $spawn_out(slave,name)`
+     after spawn), and Tcl's `\x` escape eats all following hex digits —
+     write `Esc` as `\033`, never `\x1b` followed by a hex-looking char.
+
+6. **Keep the UI discoverable.** A new key binding must appear in the footer
+   hint line in `draw_footer` (`src/ui.rs`). Mind macOS/Windows/Linux
+   differences: Option on macOS arrives as ALT (or as `Esc b`/`Esc f` from
+   Terminal.app); Cmd (SUPER) only arrives under the kitty keyboard
+   protocol, so always provide a universal fallback (Home/End, Ctrl+letter).
+
+7. **Update `CHANGELOG.md`.** Add an entry under `[Unreleased]` in the
+   matching Keep-a-Changelog section (`Added`/`Changed`/`Fixed`), written
+   for users, ending with a link to the PR.
+
+8. **Refresh the demo if visuals changed.** The README GIF is recorded with
+   [vhs](https://github.com/charmbracelet/vhs) from `demo/demo.tape`.
+
+9. **Open a PR against `main`.** Describe what changed, how it works, and
+   how it was verified (including the end-to-end check from step 5). CI must
+   pass before merge.
+
+## Releases
+
+Releases are cut by tagging `v*`; the dist-generated `release.yml` workflow
+builds binaries and publishes the Homebrew formula. Feature PRs never touch
+versioning — just leave the changelog entry under `[Unreleased]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+See @AGENTS.md for the module map and the process to follow when working on
+a feature.


### PR DESCRIPTION
## What

- **AGENTS.md**: documents the process for building a new feature — module map, keeping logic in `app.rs` and rendering in `ui.rs`, unit tests in-module, the exact quality gates CI enforces (`fmt`, `clippy -D warnings`, `test`), end-to-end verification (`--once` for logic, PTY-driven runs for TUI behavior, including the two PTY gotchas: zero-size expect PTYs and Tcl's greedy `\x` escape), footer-hint discoverability and cross-platform key-binding rules, the Keep-a-Changelog entry under `[Unreleased]`, refreshing the vhs demo, and the branch → PR flow (direct pushes to `main` are blocked).
- **CLAUDE.md**: one-liner pointing Claude Code at AGENTS.md via an `@AGENTS.md` import, so both stay in sync with a single source of truth usable by any agent or human contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)