### PR TITLE
Release to crates.io and Homebrew via a version-bump PR

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,32 @@
+# Publishes the crate to crates.io during a release. This is a dist "custom
+# publish job": release.yml calls it (see publish-jobs in dist-workspace.toml)
+# after artifacts are built and uploaded, with `secrets: inherit` — so it
+# needs a CARGO_REGISTRY_TOKEN repo secret holding a crates.io API token.
+name: Publish to crates.io
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          version="$(cargo pkgid | sed 's/.*[@#]//')"
+          # Skip when the version is already up: a release re-run after a
+          # partial failure (e.g. in the Homebrew job) must not die here.
+          if curl -fsSL -H "User-Agent: dnsglobe-release-ci" \
+              "https://crates.io/api/v1/crates/dnsglobe/versions" \
+              | jq -e --arg v "$version" '.versions[] | select(.num == $v)' > /dev/null; then
+            echo "dnsglobe $version is already on crates.io, skipping"
+            exit 0
+          fi
+          cargo publish

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -15,7 +15,7 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ name: Release
 permissions:
   "contents": "write"
 
-# This task will run whenever you push a git tag that looks like a version
+# This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
@@ -40,9 +40,13 @@ permissions:
 # will be marked as a prerelease.
 on:
   pull_request:
-  push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release Tag
+        required: true
+        default: dry-run
+        type: string
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -50,9 +54,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
+      tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
+      publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -77,7 +81,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -93,7 +97,7 @@ jobs:
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') || inputs.tag == 'dry-run' }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by dist in create-release.
@@ -324,15 +328,30 @@ jobs:
           done
           git push
 
+  custom-publish-crates:
+    needs:
+      - plan
+      - host
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: ./.github/workflows/publish-crates.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    # publish jobs get escalated permissions
+    permissions:
+      "id-token": "write"
+      "packages": "write"
+
   announce:
     needs:
       - plan
       - host
       - publish-homebrew-formula
+      - custom-publish-crates
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Dispatch release.yml if this version is untagged
         run: |
           version="$(cargo pkgid | sed 's/.*[@#]//')"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,36 @@
+# Turns a merged version-bump PR into a release: when a push to main changes
+# Cargo.toml and the crate version has no tag yet, dispatch the dist-generated
+# release.yml with that version. release.yml builds the binaries, publishes to
+# crates.io and the Homebrew tap, and creates the v* tag and GitHub release.
+#
+# workflow_dispatch is one of the two event types GITHUB_TOKEN is allowed to
+# trigger from inside a workflow, so no PAT is needed here.
+name: Release on version bump
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.toml
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dispatch release.yml if this version is untagged
+        run: |
+          version="$(cargo pkgid | sed 's/.*[@#]//')"
+          if git ls-remote --exit-code --tags origin "refs/tags/v$version" > /dev/null; then
+            echo "v$version already tagged, nothing to release"
+            exit 0
+          fi
+          echo "Dispatching release for v$version"
+          gh workflow run release.yml --ref main -f "tag=v$version"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,20 @@ methods rather than mutating state inline.
 
 ## Releases
 
-Releases are cut by tagging `v*`; the dist-generated `release.yml` workflow
-builds binaries and publishes the Homebrew formula. Feature PRs never touch
-versioning — just leave the changelog entry under `[Unreleased]`.
+Releases are cut with a version-bump PR:
+
+1. Bump `version` in `Cargo.toml` and run `cargo check` so `Cargo.lock`
+   picks up the new version.
+2. In `CHANGELOG.md`, rename `[Unreleased]` to the new version with today's
+   date and add a fresh empty `[Unreleased]` heading above it.
+3. Open a PR with just those changes and merge it.
+
+On merge, `tag-release.yml` sees the new (untagged) version on `main` and
+dispatches the dist-generated `release.yml`, which builds binaries, publishes
+to crates.io (`publish-crates.yml`, needs the `CARGO_REGISTRY_TOKEN` secret)
+and the Homebrew tap, and creates the `v*` tag and GitHub release. A release
+can also be re-run or cut manually from the Actions tab by dispatching
+`release.yml` with the tag.
+
+Feature PRs never touch versioning — just leave the changelog entry under
+`[Unreleased]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - README: Arch Linux AUR package information.
   ([#8](https://github.com/514-labs/dnsglobe/pull/8))
 
+### Changed
+
+- Releases are now cut by merging a version-bump PR: the release workflow is
+  dispatched automatically and publishes to crates.io (new) as well as
+  Homebrew, so `cargo install dnsglobe` stays current with each release.
+  ([#19](https://github.com/514-labs/dnsglobe/pull/19))
+
 ## [0.2.0] - 2026-07-05
 
 ### Added

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,9 +14,12 @@ tap = "514-labs/homebrew-tap"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
-publish-jobs = ["homebrew"]
+publish-jobs = ["homebrew", "./publish-crates"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
+# Trigger releases by workflow dispatch (the tag is created by the workflow),
+# so a merged version-bump PR can kick off a release without a manual tag push
+dispatch-releases = true
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program


### PR DESCRIPTION
## What

Cutting a release is now just merging a PR that bumps `version` in `Cargo.toml` (plus the changelog roll-over). On merge, the release pipeline runs automatically and publishes to **crates.io** (new) as well as the Homebrew tap, then creates the `v*` tag and GitHub release. No more manual tag pushes.

## How

- **`dist-workspace.toml`**: `dispatch-releases = true` switches the dist pipeline from tag-push-triggered to `workflow_dispatch`-triggered (dist creates the tag at the end of a successful release), and `publish-jobs` gains a `./publish-crates` custom job. `release.yml` was regenerated with `dist generate` (dist 0.32.0) — every change there is autogenerated.
- **`tag-release.yml`** (new): runs on pushes to `main` that touch `Cargo.toml`; if the crate version has no `v*` tag yet, it dispatches `release.yml` with `tag=v<version>`. Uses plain `GITHUB_TOKEN` — `workflow_dispatch` is exempt from GitHub's no-recursive-workflows rule, so no PAT is needed.
- **`publish-crates.yml`** (new): called by `release.yml` during the publish phase with `secrets: inherit`; runs `cargo publish`, skipping versions already on crates.io so a release re-run after a partial failure (e.g. Homebrew hiccup) stays green.
- **AGENTS.md / CHANGELOG.md**: release process documented; changelog notes crates.io publishing.

Releases can still be cut or re-run manually from the Actions tab by dispatching `release.yml` with a tag.

## ⚠️ Before merging

Add a `CARGO_REGISTRY_TOKEN` repo secret (crates.io API token with publish scope for `dnsglobe`). The crate exists on crates.io up to 0.2.0 (published manually), so CI takes over from the next bump.

## Verification

- `dist generate` + `dist plan` run clean on the new config
- `actionlint` on the two new workflows: no findings (only pre-existing style notes inside dist-generated script blocks)
- `cargo publish --dry-run` packages and verifies successfully
- The already-published guard and the tag-existence check were both exercised locally: 0.2.0 correctly detected as published/tagged (→ skip), 0.3.0 as unpublished/untagged (→ would dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)