### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-06
+
 ### Added
 
 - Word and line cursor motions in the domain input: Option/Alt+←/→ (or
@@ -106,7 +108,8 @@ Initial release.
   that re-polls every 30s until all responding resolvers agree.
 - `--once` plain-text mode for scripts.
 
-[Unreleased]: https://github.com/514-labs/dnsglobe/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/514-labs/dnsglobe/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/514-labs/dnsglobe/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/514-labs/dnsglobe/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/514-labs/dnsglobe/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/514-labs/dnsglobe/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "dnsglobe"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnsglobe"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal"


### PR DESCRIPTION
Version-bump PR to cut v0.3.0 — the first release through the new automated pipeline (#19).

- `Cargo.toml`/`Cargo.lock`: 0.2.0 → 0.3.0
- `CHANGELOG.md`: `[Unreleased]` rolled over to `[0.3.0] - 2026-07-06`, compare links updated

On merge, `tag-release.yml` dispatches the dist release pipeline, which builds binaries, publishes to crates.io and the Homebrew tap, and creates the `v0.3.0` tag and GitHub release.

Verified locally: `cargo check` clean, `dist plan` announces v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)