### PR TITLE
Count SERVFAIL as a propagation signal instead of discarding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- SERVFAIL answers now count as a propagation signal instead of being
+  discarded as unreachable. A resolver answering SERVFAIL is saying "I tried
+  to resolve this name and could not" — the exact state of a resolver stuck
+  on a delegation whose old nameservers were deleted mid-NS-migration (or a
+  DNSSEC validation failure). Such resolvers now hold the propagation
+  percentage below 100% and keep watch mode polling; they show as
+  `✗ SERVFAIL` in the table (`FAIL` in `--once` output) with their own
+  footer count. Previously they were lumped in with timeouts/refusals, so a
+  broken delegation could report as fully propagated.
+  ([#21](https://github.com/514-labs/dnsglobe/pull/21))
+
 ## [0.3.0] - 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `✗ SERVFAIL` in the table (`FAIL` in `--once` output) with their own
   footer count. Previously they were lumped in with timeouts/refusals, so a
   broken delegation could report as fully propagated.
-  ([#21](https://github.com/514-labs/dnsglobe/pull/23))
+  ([#23](https://github.com/514-labs/dnsglobe/pull/23))
 
 ## [0.3.0] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `✗ SERVFAIL` in the table (`FAIL` in `--once` output) with their own
   footer count. Previously they were lumped in with timeouts/refusals, so a
   broken delegation could report as fully propagated.
-  ([#21](https://github.com/514-labs/dnsglobe/pull/21))
+  ([#21](https://github.com/514-labs/dnsglobe/pull/23))
 
 ## [0.3.0] - 2026-07-06
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -125,10 +125,13 @@ pub struct Summary {
     pub done: usize,
     pub ok: usize,
     pub no_records: usize,
+    pub servfail: usize,
     pub errors: usize,
-    /// Resolvers that gave a usable answer (records or an authoritative
-    /// "no records"). Timeouts and refusals say nothing about propagation,
-    /// so percentages are computed against this, not the full list.
+    /// Resolvers that gave a usable answer (records, an authoritative
+    /// "no records", or a SERVFAIL — the resolver's view of the domain is
+    /// "broken", a real state during an NS migration). Timeouts and refusals
+    /// say nothing about propagation, so percentages are computed against
+    /// this, not the full list.
     pub responding: usize,
     /// Distinct answer *groups*. Answers sharing any record are grouped
     /// together, so round-robin subsets of one pool count as a single group
@@ -444,15 +447,16 @@ impl App {
                 let now = Instant::now();
                 order.sort_by_key(|&i| match &self.rows[i] {
                     RowState::Done { result, .. } => match result {
-                        QueryResult::Records { .. } if in_flight || summary.majority_rows[i] => 4,
+                        QueryResult::Records { .. } if in_flight || summary.majority_rows[i] => 5,
                         // Misbehaving caches are the most actionable rows.
                         QueryResult::Records { .. } if self.ttl_verdict(i, now).is_some() => 0,
                         QueryResult::Records { .. } => 1, // differs
                         QueryResult::NoRecords(_) => 2,
-                        QueryResult::Error(_) => 3,
+                        QueryResult::ServFail => 3,
+                        QueryResult::Error(_) => 4,
                     },
-                    RowState::Pending => 5,
-                    RowState::Idle => 6,
+                    RowState::Pending => 6,
+                    RowState::Idle => 7,
                 });
             }
             SortMode::Answer => order.sort_by(|&a, &b| {
@@ -519,10 +523,11 @@ impl App {
                     }
                 }
                 QueryResult::NoRecords(_) => summary.no_records += 1,
+                QueryResult::ServFail => summary.servfail += 1,
                 QueryResult::Error(_) => summary.errors += 1,
             }
         }
-        summary.responding = summary.ok + summary.no_records;
+        summary.responding = summary.ok + summary.no_records + summary.servfail;
 
         let mut counts: HashMap<usize, usize> = HashMap::new();
         for &i in &ok_rows {
@@ -891,6 +896,44 @@ mod tests {
         let app = app_with_answers(&[&["x"], &["x"]]);
         let summary = app.summary();
         assert_eq!(app.stale_expiry_bound(&summary, Instant::now()), None);
+    }
+
+    #[test]
+    fn servfail_counts_as_responding_and_blocks_full_propagation() {
+        // A resolver stuck on a delegation whose nameservers were deleted
+        // answers SERVFAIL: that's "not propagated here", not noise — it must
+        // hold the percentage below 100% and keep watch mode polling.
+        let mut app = app_with_answers(&[&["x"], &["x"]]);
+        app.rows.push(RowState::Done {
+            result: QueryResult::ServFail,
+            elapsed: Duration::from_millis(20),
+            at: Instant::now(),
+        });
+        let s = app.summary();
+        assert_eq!(s.servfail, 1);
+        assert_eq!(s.errors, 0);
+        assert_eq!(s.responding, 3);
+        assert_eq!(s.agree, 2);
+        assert!(s.agree < s.responding);
+    }
+
+    #[test]
+    fn status_sort_ranks_servfail_between_no_records_and_errors() {
+        let mut app = app_with_answers(&[&["x"]]);
+        for result in [
+            QueryResult::Error("timeout".into()),
+            QueryResult::ServFail,
+            QueryResult::NoRecords("NXDOMAIN".into()),
+        ] {
+            app.rows.push(RowState::Done {
+                result,
+                elapsed: Duration::from_millis(20),
+                at: Instant::now(),
+            });
+        }
+        app.sort = SortMode::Status;
+        let summary = app.summary();
+        assert_eq!(app.display_order(&summary), vec![3, 2, 1, 0]);
     }
 
     #[test]

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -19,9 +19,15 @@ pub enum QueryResult {
     /// signal — the server's view is "nothing there" — so it counts toward
     /// the responding total.
     NoRecords(String),
+    /// SERVFAIL: the resolver tried to resolve this name and could not —
+    /// typically a delegation pointing at dead nameservers (mid-NS-migration
+    /// with the old servers gone) or a DNSSEC validation failure. Unlike
+    /// REFUSED or a timeout this is a statement about the *domain*, so it
+    /// counts toward the responding total and blocks 100% propagation.
+    ServFail,
     /// No usable answer: timeout, network error, or the server refused to
-    /// serve us (REFUSED/SERVFAIL). Says nothing about propagation, so these
-    /// are excluded from the percentage.
+    /// serve us (REFUSED). Says nothing about propagation, so these are
+    /// excluded from the percentage.
     Error(String),
 }
 
@@ -79,11 +85,14 @@ pub async fn query(server: IpAddr, domain: String, rtype: RecordType) -> (QueryR
         Err(_) => QueryResult::Error("timeout".into()),
         Ok(Err(err)) => match err {
             NetError::Timeout => QueryResult::Error("timeout".into()),
-            // "Won't serve you" / "couldn't resolve" — not a statement about
-            // whether the record exists.
+            // "Won't serve you" — a policy about us as a client, not a
+            // statement about whether the record exists.
             NetError::Dns(DnsError::ResponseCode(ResponseCode::Refused)) => {
                 QueryResult::Error("refused".into())
             }
+            // hickory's error drops the EDE detail (e.g. "no reachable
+            // authority"), so the classification is all we get.
+            NetError::Dns(DnsError::ResponseCode(ResponseCode::ServFail)) => QueryResult::ServFail,
             NetError::Dns(DnsError::ResponseCode(code)) => QueryResult::Error(code.to_string()),
             NetError::Dns(DnsError::NoRecordsFound(no_records)) => {
                 QueryResult::NoRecords(no_records.response_code.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,9 @@ async fn run_tui(
                 if !app.in_flight() {
                     // Round complete: stop watching once every responding
                     // resolver agrees (refused/unreachable ones carry no
-                    // propagation signal), otherwise schedule the next poll.
+                    // propagation signal; SERVFAIL counts as responding, so
+                    // a broken delegation keeps the watch alive), otherwise
+                    // schedule the next poll.
                     let summary = app.summary();
                     if summary.responding > 0 && summary.agree == summary.responding {
                         app.auto_refresh = false;
@@ -383,6 +385,12 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
                 dns::QueryResult::NoRecords(code) => {
                     format!("NONE    {:>5}ms  {code}", elapsed.as_millis())
                 }
+                dns::QueryResult::ServFail => {
+                    format!(
+                        "FAIL    {:>5}ms  SERVFAIL (can't resolve — broken delegation or DNSSEC?)",
+                        elapsed.as_millis()
+                    )
+                }
                 dns::QueryResult::Error(err) => {
                     format!("ERR     {:>5}ms  {err}", elapsed.as_millis())
                 }
@@ -402,8 +410,8 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
     }
 
     println!(
-        "\n{} of {} responding · {} unreachable · {} answer group(s)",
-        summary.ok, summary.responding, summary.errors, summary.groups
+        "\n{} of {} responding · {} servfail · {} unreachable · {} answer group(s)",
+        summary.ok, summary.responding, summary.servfail, summary.errors, summary.groups
     );
     if summary.agree > 0 {
         println!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -164,6 +164,9 @@ fn draw_gauge(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
             summary.responding,
             ratio * 100.0
         );
+        if summary.servfail > 0 {
+            label.push_str(&format!(" · {} servfail", summary.servfail));
+        }
         if summary.errors > 0 {
             label.push_str(&format!(" · {} unreachable", summary.errors));
         }
@@ -294,6 +297,19 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                             Cell::from(Span::styled("∅ NONE", Style::new().fg(Color::Red).bold())),
                             Cell::from(Span::styled(code.clone(), Style::new().fg(Color::Red))),
                         ),
+                        QueryResult::ServFail => (
+                            time,
+                            Cell::from(""),
+                            Cell::from(""),
+                            Cell::from(Span::styled(
+                                "✗ SERVFAIL",
+                                Style::new().fg(Color::Red).bold(),
+                            )),
+                            Cell::from(Span::styled(
+                                "can't resolve — broken delegation or DNSSEC?",
+                                Style::new().fg(Color::Red),
+                            )),
+                        ),
                         QueryResult::Error(message) => (
                             time,
                             Cell::from(""),
@@ -406,7 +422,9 @@ fn draw_map(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, are
                                 }
                             }
                         }
-                        QueryResult::NoRecords(_) | QueryResult::Error(_) => Color::Red,
+                        QueryResult::NoRecords(_)
+                        | QueryResult::ServFail
+                        | QueryResult::Error(_) => Color::Red,
                     },
                 };
                 ctx.print(lon, lat, Span::styled("●", Style::new().fg(color).bold()));
@@ -481,6 +499,11 @@ fn draw_footer(
         status.push_span(Span::raw(" · "));
         status.push_span(Span::styled(
             format!("{} none", summary.no_records),
+            Style::new().fg(Color::Red),
+        ));
+        status.push_span(Span::raw(" · "));
+        status.push_span(Span::styled(
+            format!("{} servfail", summary.servfail),
             Style::new().fg(Color::Red),
         ));
         status.push_span(Span::raw(" · "));


### PR DESCRIPTION
## What

SERVFAIL answers were lumped into `QueryResult::Error` alongside timeouts and REFUSED, excluding them from the responding total. A domain mid-NS-migration whose old nameservers were deleted could therefore report **fully propagated** while a chunk of the world still can't resolve it at all (found live on `boreal.cloud`: Hurricane Electric et al. answer SERVFAIL with EDE 22 "no reachable authority").

## How

SERVFAIL is a statement about the *domain* ("I tried to resolve this name and could not" — dead delegation or DNSSEC failure), unlike REFUSED (policy about the client) or a timeout (network path). So it gets its own `QueryResult::ServFail` variant that:

- counts toward `Summary::responding`, holding the propagation percentage below 100% and keeping watch mode polling until the resolver recovers
- renders as `✗ SERVFAIL` in the table (red map dot, own gauge/footer counts), `FAIL` in `--once` output
- sorts between NONE and ERR under the Status sort

hickory's high-level lookup drops the EDE detail, so the row text stays generic ("can't resolve — broken delegation or DNSSEC?").

## Verified

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (44 passed, incl. 2 new: SERVFAIL counts as responding & blocks 100%; status-sort ranking)
- End-to-end via `cargo run -- boreal.cloud ns --once`: 16 resolvers show `FAIL … SERVFAIL`, summary reads `14 of 30 responding · 16 servfail · 4 unreachable` and propagation `12/30` — previously those 16 were silently dropped and it would have read 12/14
- TUI through an expect PTY (`stty rows 45 columns 200`): asserted `✗ SERVFAIL` rows and the gauge's servfail count render, then clean Esc quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)