### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-06
+
 ### Fixed
 
 - SERVFAIL answers now count as a propagation signal instead of being
@@ -121,7 +123,8 @@ Initial release.
   that re-polls every 30s until all responding resolvers agree.
 - `--once` plain-text mode for scripts.
 
-[Unreleased]: https://github.com/514-labs/dnsglobe/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/514-labs/dnsglobe/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/514-labs/dnsglobe/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/514-labs/dnsglobe/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/514-labs/dnsglobe/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/514-labs/dnsglobe/compare/v0.1.0...v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "dnsglobe"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnsglobe"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal"


### PR DESCRIPTION
Version bump to 0.3.1 for the SERVFAIL propagation-signal fix (#23). On merge, `tag-release.yml` dispatches the release workflow to build binaries, publish to crates.io and Homebrew, and create the `v0.3.1` tag and GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)