### PR TITLE
Keep the majority answer visible below a height-capped globe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,11 @@ methods rather than mutating state inline.
 
 7. **Update `CHANGELOG.md`.** Add an entry under `[Unreleased]` in the
    matching Keep-a-Changelog section (`Added`/`Changed`/`Fixed`), written
-   for users, ending with a link to the PR.
+   for users, ending with a link to the PR. Exception: fixing a bug that was
+   itself introduced in `[Unreleased]` gets no entry — no released version
+   ever had the bug, so there is nothing for users to note. If the fix
+   changes behavior that an existing `[Unreleased]` entry describes, amend
+   that entry instead.
 
 8. **Refresh the demo if visuals changed.** The README GIF is recorded with
    [vhs](https://github.com/charmbracelet/vhs) from `demo/demo.tape`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,14 +44,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ([#25](https://github.com/514-labs/dnsglobe/issues/25),
   [#27](https://github.com/514-labs/dnsglobe/pull/27))
 
-### Fixed
-
-- On terminals both wide and tall, the globe no longer grows over the
-  majority-answer panel below it: the globe now cedes exactly the rows that
-  panel needs (legend only while idle, plus the answer list once a round
-  settles), so the resolved values stay visible in globe view.
-  ([#28](https://github.com/514-labs/dnsglobe/pull/28))
-
 ## [0.3.1] - 2026-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ([#25](https://github.com/514-labs/dnsglobe/issues/25),
   [#27](https://github.com/514-labs/dnsglobe/pull/27))
 
+### Fixed
+
+- On terminals both wide and tall, the globe no longer grows over the
+  majority-answer panel below it: the globe now cedes exactly the rows that
+  panel needs (legend only while idle, plus the answer list once a round
+  settles), so the resolved values stay visible in globe view.
+  ([#28](https://github.com/514-labs/dnsglobe/pull/28))
+
 ## [0.3.1] - 2026-07-06
 
 ### Fixed

--- a/src/globe.rs
+++ b/src/globe.rs
@@ -40,8 +40,6 @@ pub const MAP_LAT_SPAN: f64 = 127.0;
 /// filling available height is what keeps the continents recognizable.
 pub const MAP_ASPECT: f64 = MAP_LAT_SPAN / MAP_LON_SPAN * 2.0 / 4.0;
 pub const MAP_MAX_WIDTH: u16 = 170;
-/// Panel rows kept below the globe for the legend/majority-answer box.
-const INFO_RESERVE: u16 = 4;
 
 /// Map panel dimensions and canvas zoom, all interpolated by the morph so
 /// the panel itself reshapes with the transition.
@@ -66,21 +64,24 @@ impl PanelGeom {
 }
 
 /// Size the map panel at morph parameter `t`, given the columns available to
-/// it and the body height. The flat endpoint is the classic wide panel; the
+/// it, the body height, and the rows the info box below the globe currently
+/// needs (`info_rows`). The flat endpoint is the classic wide panel; the
 /// globe endpoint is a square dot grid (2 braille dots per cell horizontally,
 /// 4 vertically → cell height ≈ half the width) just big enough for the disc,
 /// so the globe earns its keep on narrow terminals instead of floating small
 /// inside a map-shaped canvas. Between the endpoints everything lerps:
 /// width, height, and zoom animate together with the coastline morph.
-pub fn panel_geometry(avail_width: u16, body_height: u16, t: f64) -> PanelGeom {
+pub fn panel_geometry(avail_width: u16, body_height: u16, t: f64, info_rows: u16) -> PanelGeom {
     // Floors keep the geometry sane (and division-safe) on degenerate
     // terminal sizes; ceilings are lifted to the floor so clamp can't panic.
     let flat_w = avail_width.clamp(6, MAP_MAX_WIDTH);
     let flat_h =
         ((f64::from(flat_w - 2) * MAP_ASPECT).round() as u16 + 2).clamp(4, body_height.max(4));
     // Square dot grid for the globe, height-capped so the info box below
-    // keeps its rows on wide-but-short terminals.
-    let globe_h = ((flat_w - 2) / 2 + 2).clamp(4, body_height.saturating_sub(INFO_RESERVE).max(4));
+    // keeps its rows: on terminals both wide and tall the globe would
+    // otherwise grow past body_height − info_rows and clip the majority
+    // answer out of view.
+    let globe_h = ((flat_w - 2) / 2 + 2).clamp(4, body_height.saturating_sub(info_rows).max(4));
     let globe_w = (2 * (globe_h - 2) + 2).clamp(6, flat_w);
     // Degrees per dot equal in x and y ⇒ round limb, whatever the clamps did.
     let globe_span = MAP_LAT_SPAN * f64::from(globe_w - 2) / (2.0 * f64::from(globe_h - 2));
@@ -314,7 +315,7 @@ mod tests {
 
     #[test]
     fn flat_geometry_matches_the_classic_panel() {
-        let g = panel_geometry(80, 50, 0.0);
+        let g = panel_geometry(80, 50, 0.0, 4);
         assert_eq!(g.width, 80);
         assert_eq!(g.height, (78.0 * MAP_ASPECT).round() as u16 + 2);
         assert!((g.x_span - MAP_LON_SPAN).abs() < EPS);
@@ -324,7 +325,7 @@ mod tests {
 
     #[test]
     fn globe_geometry_is_a_square_dot_grid_that_fits_the_disc() {
-        let g = panel_geometry(80, 50, 1.0);
+        let g = panel_geometry(80, 50, 1.0, 4);
         // 2 dots/cell wide × 4 tall: square grid means height ≈ width/2.
         assert_eq!(g.height, (g.width - 2) / 2 + 2);
         // Zoomed so the 127° lat span fills the panel: the disc (2×RADIUS
@@ -336,7 +337,7 @@ mod tests {
     fn short_terminals_shrink_the_globe_panel_and_keep_it_round() {
         // Height-capped: the panel narrows to stay square instead of leaving
         // the globe floating in a wide canvas.
-        let g = panel_geometry(160, 30, 1.0);
+        let g = panel_geometry(160, 30, 1.0, 4);
         assert!(g.height <= 30 - 4);
         assert_eq!(g.width, 2 * (g.height - 2) + 2);
         // Round limb invariant: degrees per dot equal in x and y.
@@ -346,9 +347,23 @@ mod tests {
     }
 
     #[test]
+    fn info_rows_shrink_a_height_capped_globe() {
+        // Wide and tall enough that only the height cap binds: every extra
+        // info row comes straight out of the globe, which stays square.
+        let legend_only = panel_geometry(160, 40, 1.0, 4);
+        let with_answers = panel_geometry(160, 40, 1.0, 9);
+        assert_eq!(legend_only.height, 40 - 4);
+        assert_eq!(with_answers.height, 40 - 9);
+        assert_eq!(with_answers.width, 2 * (with_answers.height - 2) + 2);
+        // Width-capped globes are untouched: they already leave the rows.
+        let small = panel_geometry(40, 40, 1.0, 4);
+        assert_eq!(small.height, panel_geometry(40, 40, 1.0, 9).height);
+    }
+
+    #[test]
     fn geometry_survives_degenerate_sizes() {
         for (w, h) in [(0, 0), (1, 1), (6, 4), (7, 50), (300, 2)] {
-            let g = panel_geometry(w, h, 1.0);
+            let g = panel_geometry(w, h, 1.0, 9);
             assert!(g.width >= 6 && g.height >= 4);
             assert!(g.x_span.is_finite() && g.x_span > 0.0);
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -88,7 +88,7 @@ fn info_rows(app: &App, summary: &Summary, complete: bool) -> u16 {
     if complete && !summary.majority_values.is_empty() {
         // Blank + heading + one row per value, capped so a many-valued
         // record (TXT, round-robin pools) doesn't crush the globe.
-        legend + 2 + summary.majority_values.len().min(4) as u16
+        legend + 2 + summary.majority_values.len().min(20) as u16
     } else if app.queried.is_some() && app.in_flight() {
         legend + 2 // blank + "waiting for all resolvers…"
     } else {
@@ -667,7 +667,7 @@ mod tests {
         assert_eq!(info_rows(&app, &summary, true), 8);
 
         // …capped so a many-valued record doesn't crush the globe.
-        summary.majority_values = vec!["v".into(); 20];
-        assert_eq!(info_rows(&app, &summary, true), 10);
+        summary.majority_values = vec!["v".into(); 30];
+        assert_eq!(info_rows(&app, &summary, true), 26);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -45,6 +45,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         body.width.saturating_sub(TABLE_WIDTH),
         body.height,
         app.globe.t(Instant::now()),
+        info_rows(app, &summary, complete),
     );
     let min_width = if app.globe.target() {
         MIN_WIDTH_FOR_GLOBE
@@ -75,6 +76,24 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_map_info(frame, app, &summary, complete, info_area);
     }
     draw_footer(frame, app, &summary, advisory, footer);
+}
+
+/// Rows to reserve below the globe for the info box, mirroring what
+/// `draw_map_info` will render: borders plus the legend (which wraps to two
+/// lines on narrow panels), plus the majority-answer block once a round has
+/// settled. Passing this into the panel geometry keeps a height-capped globe
+/// from growing over the answers on terminals both wide and tall.
+fn info_rows(app: &App, summary: &Summary, complete: bool) -> u16 {
+    let legend = 4; // two borders + the legend's up-to-two wrapped lines
+    if complete && !summary.majority_values.is_empty() {
+        // Blank + heading + one row per value, capped so a many-valued
+        // record (TXT, round-robin pools) doesn't crush the globe.
+        legend + 2 + summary.majority_values.len().min(4) as u16
+    } else if app.queried.is_some() && app.in_flight() {
+        legend + 2 // blank + "waiting for all resolvers…"
+    } else {
+        legend
+    }
 }
 
 /// One-line "lower your TTL before migrating" hint, shown once a round has
@@ -623,5 +642,32 @@ fn draw_footer(
             Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).areas(area);
         frame.render_widget(Paragraph::new(status), status_area);
         frame.render_widget(Paragraph::new(keys), keys_area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_rows_track_what_the_info_box_will_show() {
+        let mut app = App::new("example.com".into());
+        let mut summary = app.summary();
+
+        // Nothing queried yet: just borders + legend.
+        assert_eq!(info_rows(&app, &summary, false), 4);
+
+        // Mid-round: the "waiting for all resolvers…" note needs two rows.
+        app.begin_query().unwrap();
+        assert_eq!(info_rows(&app, &summary, false), 6);
+
+        // Settled round: blank + heading + one row per majority value…
+        app.rows = vec![RowState::Idle; app.rows.len()];
+        summary.majority_values = vec!["192.0.2.1".into(), "192.0.2.2".into()];
+        assert_eq!(info_rows(&app, &summary, true), 8);
+
+        // …capped so a many-valued record doesn't crush the globe.
+        summary.majority_values = vec!["v".into(); 20];
+        assert_eq!(info_rows(&app, &summary, true), 10);
     }
 }


### PR DESCRIPTION
## What changed

On terminals both wide and tall, the globe grew until it hit its height cap — which reserved a fixed `INFO_RESERVE = 4` rows below it, enough for the color legend but not for the "Majority answer" block. The resolved values were silently clipped out of the info panel (report: globe view on a large window after #26/#27).

The reserve is now dynamic: `ui::draw` computes the rows `draw_map_info` will actually render and passes them into `globe::panel_geometry`:

- idle / no query: 4 rows (borders + legend, which wraps to two lines on narrow panels) — the globe keeps its current size;
- round in flight: +2 for the "waiting for all resolvers…" note;
- round settled: +2 (blank + heading) + one row per majority value, capped at 20 so a many-valued record (TXT, round-robin pools) doesn't crush the globe.

A width-capped globe (narrow terminals) is unaffected — it already left more rows than the reserve. The globe shrinks by a few rows the moment a round completes; the existing morph/lerp only animates the flat↔globe transition, so this is a single reflow, which reads as the panel making room for the answers.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (73 passing, including a new `panel_geometry` test that the reserve comes straight out of a height-capped globe and leaves width-capped ones alone, and a `ui::info_rows` test covering idle/in-flight/settled/capped).
- End-to-end through an `expect` PTY at 50×200 (a size where the globe is height-capped), running `dnsglobe 514.ax --view globe` against the network and grepping the raw output:
  - pre-fix binary: round completes (`complete` rendered), `Majority answer` **never appears** — the reported bug reproduced;
  - post-fix binary: same run, `Majority answer` renders.
- Demo GIF unchanged: at the demo's terminal size the globe is width-capped, so its geometry is identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
