### PR TITLE
Add EDNS Client Subnet (ECS) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- EDNS Client Subnet (RFC 7871) support: `--ecs 203.0.113.0/24` (or
+  `ecs = [...]` in the config file) attaches that client subnet to every
+  query, so GeoDNS zones answer for that network instead of each resolver's
+  own vantage point. Takes CIDRs or bare IPs, and accepts several subnets to
+  compare how answers converge across client networks: Ctrl+N cycles the
+  active subnet in the TUI, and `--once` prints one table per subnet plus a
+  convergence summary. Resolvers that deliberately ignore ECS (Cloudflare,
+  Quad9, …) are tagged `NO ECS` and left out of the propagation percentage —
+  their answer describes their own location, not the probed network.
+  ([#14](https://github.com/514-labs/dnsglobe/issues/14),
+  [#29](https://github.com/514-labs/dnsglobe/pull/29))
 - 3D rotating globe view: the flat resolver map can morph into a spinning
   orthographic globe, with the resolver status dots riding their continents
   and hiding on the far hemisphere as the planet turns. The globe keeps the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   query, so GeoDNS zones answer for that network instead of each resolver's
   own vantage point. Takes CIDRs or bare IPs, and accepts several subnets to
   compare how answers converge across client networks: Ctrl+N cycles the
-  active subnet in the TUI, and `--once` prints one table per subnet plus a
-  convergence summary. Resolvers that deliberately ignore ECS (Cloudflare,
+  active subnet in the TUI (re-querying as it goes), and `--once` prints one
+  table per subnet plus a convergence summary. Resolvers that deliberately ignore ECS (Cloudflare,
   Quad9, …) are tagged `NO ECS` and left out of the propagation percentage —
   their answer describes their own location, not the probed network.
   ([#14](https://github.com/514-labs/dnsglobe/issues/14),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Tab / Shift-Tab now re-query the checked domain with the newly selected
+  record type right away, instead of waiting for Enter — matching the new
+  Ctrl+N behavior for ECS subnets.
+  ([#29](https://github.com/514-labs/dnsglobe/pull/29))
 - The default palette now stays legible on terminal themes with mid-toned
   backgrounds, like macOS Terminal's "Ocean": de-emphasized text uses the
   faint attribute instead of dark gray (dimming your theme's own foreground

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ option ([RFC 7871](https://datatracker.ietf.org/doc/html/rfc7871)) to every
 query, so GeoDNS zones answer for that client network instead of the
 resolver's own vantage point. Subnets are CIDRs or bare IPs; most public
 resolvers use at most /24 (IPv4) or /56 (IPv6). With several subnets
-configured, Ctrl+N cycles the active one (plus an *off* position) and the
-next Enter queries with it; `--once` runs every subnet and ends with a
+configured, Ctrl+N cycles the active one (plus an *off* position) and
+re-queries immediately; `--once` runs every subnet and ends with a
 per-subnet convergence summary. Resolvers that deliberately ignore ECS
 (Cloudflare, Quad9, …) are tagged `NO ECS` — their answer is shown for
 reference but excluded from the propagation percentage, since it describes
@@ -89,7 +89,7 @@ their own location, not the probed network.
 | Tab / Shift-Tab | select record type (A, AAAA, CNAME, MX, NS, TXT, SOA) |
 | ↑/↓ / PgUp/PgDn | scroll the resolver table |
 | Ctrl+S         | cycle table sort: resolver / location / time / status / answer |
-| Ctrl+N         | cycle the ECS client subnet (only when `--ecs`/config set one up) |
+| Ctrl+N         | cycle the ECS client subnet and re-query (only when `--ecs`/config set one up) |
 | Ctrl+U         | clear domain                    |
 | Esc / Ctrl+C   | quit                            |
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ their own location, not the probed network.
 | ←/→ / Home/End | move cursor in the domain field |
 | Enter          | start the check and watch: re-polls every 30 s until propagation reaches 100% |
 | Ctrl+R         | stop or resume watching         |
-| Tab / Shift-Tab | select record type (A, AAAA, CNAME, MX, NS, TXT, SOA) |
+| Tab / Shift-Tab | select record type (A, AAAA, CNAME, MX, NS, TXT, SOA) and re-query |
 | ↑/↓ / PgUp/PgDn | scroll the resolver table |
 | Ctrl+S         | cycle table sort: resolver / location / time / status / answer |
 | Ctrl+N         | cycle the ECS client subnet and re-query (only when `--ecs`/config set one up) |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,24 @@ dnsglobe                            # start empty, type a domain
 dnsglobe example.com                # query immediately and watch
 dnsglobe example.com TXT            # same, starting on TXT records
 dnsglobe --once example.com TXT     # no TUI: print results, exit (for scripts)
+dnsglobe example.com --ecs 203.0.113.0/24        # see the zone as that client network does
+dnsglobe --once example.com --ecs 203.0.113.0/24,198.51.100.0/24
+                                    # one table per subnet + a convergence summary
 ```
+
+### EDNS Client Subnet (ECS)
+
+`--ecs` (or `ecs = [...]` in the config file) attaches an EDNS Client Subnet
+option ([RFC 7871](https://datatracker.ietf.org/doc/html/rfc7871)) to every
+query, so GeoDNS zones answer for that client network instead of the
+resolver's own vantage point. Subnets are CIDRs or bare IPs; most public
+resolvers use at most /24 (IPv4) or /56 (IPv6). With several subnets
+configured, Ctrl+N cycles the active one (plus an *off* position) and the
+next Enter queries with it; `--once` runs every subnet and ends with a
+per-subnet convergence summary. Resolvers that deliberately ignore ECS
+(Cloudflare, Quad9, …) are tagged `NO ECS` — their answer is shown for
+reference but excluded from the propagation percentage, since it describes
+their own location, not the probed network.
 
 ### Keys
 
@@ -72,6 +89,7 @@ dnsglobe --once example.com TXT     # no TUI: print results, exit (for scripts)
 | Tab / Shift-Tab | select record type (A, AAAA, CNAME, MX, NS, TXT, SOA) |
 | ↑/↓ / PgUp/PgDn | scroll the resolver table |
 | Ctrl+S         | cycle table sort: resolver / location / time / status / answer |
+| Ctrl+N         | cycle the ECS client subnet (only when `--ecs`/config set one up) |
 | Ctrl+U         | clear domain                    |
 | Esc / Ctrl+C   | quit                            |
 
@@ -86,6 +104,9 @@ use a different path.
 # Set to true to replace the built-in list instead of extending it —
 # e.g. to watch propagation across your own nameservers only.
 replace = false
+
+# EDNS Client Subnet(s) to query with (Ctrl+N cycles; --ecs overrides).
+ecs = ["203.0.113.0/24"]
 
 [[resolvers]]
 name = "Corp DNS"        # required — shown in the Resolver column
@@ -116,9 +137,9 @@ coastline = "gray"        # map/globe land outline
 grid      = "244"         # globe graticule and limb
 ```
 
-Invalid config (bad IP, unknown key, unrecognized color, `lat` without
-`lon`, `replace = true` with no resolvers) is reported at startup with the
-offending entry named.
+Invalid config (bad IP, unknown key, unrecognized color, bad `ecs` subnet,
+`lat` without `lon`, `replace = true` with no resolvers) is reported at
+startup with the offending entry named.
 
 ## Notes
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -385,7 +385,7 @@ impl App {
     }
 
     /// Ctrl+N: step the selection through the configured subnets plus an
-    /// "off" position. The caller follows up with `begin_ecs_requery` so the
+    /// "off" position. The caller follows up with `begin_reselect` so the
     /// table refreshes for the new subnet without waiting for Enter.
     pub fn cycle_ecs(&mut self) {
         if self.ecs_list.is_empty() {
@@ -408,16 +408,14 @@ impl App {
         Some(self.arm_round(domain, self.record_type()))
     }
 
-    /// Arm a fresh round for the already-queried domain/type with the
-    /// current ECS selection: Ctrl+N re-queries as it cycles. Reads
-    /// `queried`, not the (possibly mid-edit) input field, and does nothing
-    /// before the first query — there's nothing to refresh yet.
-    pub fn begin_ecs_requery(&mut self) -> Option<Round> {
-        if self.ecs_list.is_empty() {
-            return None;
-        }
-        let (domain, rtype, _) = self.queried.clone()?;
-        Some(self.arm_round(domain, rtype))
+    /// Arm a fresh round for the already-queried domain with the current
+    /// record-type and ECS selections: Tab and Ctrl+N re-query as they
+    /// cycle. Reads `queried`'s domain, not the (possibly mid-edit) input
+    /// field, and does nothing before the first query — there's nothing to
+    /// refresh yet.
+    pub fn begin_reselect(&mut self) -> Option<Round> {
+        let (domain, ..) = self.queried.clone()?;
+        Some(self.arm_round(domain, self.record_type()))
     }
 
     /// Reset every row and start a round of all resolvers, capturing the
@@ -446,7 +444,7 @@ impl App {
     /// gets re-checked and can flip.
     pub fn begin_requery(&mut self) -> Option<Round> {
         // Re-polls stay on the queried round's ECS subnet (Ctrl+N re-arms
-        // `queried` via begin_ecs_requery, so the two can't drift) — mixing
+        // `queried` via begin_reselect, so the two can't drift) — mixing
         // subnets within one table would make the group comparison
         // meaningless.
         let (domain, rtype, ecs) = self.queried.clone()?;
@@ -1212,7 +1210,7 @@ mod tests {
 
         // Before any query there's nothing to refresh: cycling alone.
         app.cycle_ecs();
-        assert!(app.begin_ecs_requery().is_none());
+        assert!(app.begin_reselect().is_none());
         app.cycle_ecs(); // back around: off
         app.cycle_ecs(); // first subnet again
         assert_eq!(app.active_ecs(), Some(list[0]));
@@ -1222,13 +1220,30 @@ mod tests {
         // even while the input field is mid-edit.
         app.insert_char('x');
         app.cycle_ecs();
-        let round = app.begin_ecs_requery().unwrap();
+        let round = app.begin_reselect().unwrap();
         assert_eq!(round.domain, "example.com");
         assert_eq!(round.ecs, Some(list[1]));
         assert!(round.generation > first.generation);
         assert_eq!(round.indices.len(), resolvers::active().len());
         // The new round is what re-polls now follow.
         assert_eq!(app.queried.as_ref().unwrap().2, Some(list[1]));
+    }
+
+    #[test]
+    fn tab_requeries_with_the_new_record_type() {
+        let mut app = App::new("example.com".into());
+        // Nothing queried yet: cycling the type refreshes nothing.
+        app.cycle_record_type(true);
+        assert!(app.begin_reselect().is_none());
+
+        app.begin_query().unwrap();
+        app.insert_char('x'); // mid-edit input must not leak into the round
+        app.cycle_record_type(true);
+        let round = app.begin_reselect().unwrap();
+        assert_eq!(round.domain, "example.com");
+        assert_eq!(round.rtype, RECORD_TYPES[2]); // A → AAAA → CNAME
+        // Re-polls follow the new type.
+        assert_eq!(app.queried.as_ref().unwrap().1, RECORD_TYPES[2]);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use hickory_resolver::proto::rr::RecordType;
 
-use crate::dns::{QueryOutcome, QueryResult};
+use crate::dns::{ClientSubnet, QueryOutcome, QueryResult};
 use crate::globe::GlobeView;
 use crate::resolvers;
 use crate::sites::Site;
@@ -98,6 +98,9 @@ pub enum RowState {
         elapsed: Duration,
         /// When the answer arrived; anchors the cache-expiry countdown.
         at: Instant,
+        /// Whether the resolver honored the round's ECS option (see
+        /// `QueryOutcome::ecs_honored`). Always None on ECS-less rounds.
+        ecs_honored: Option<bool>,
     },
 }
 
@@ -162,6 +165,22 @@ pub struct Summary {
     pub majority_rows: Vec<bool>,
     /// Union of record values across the largest group.
     pub majority_values: Vec<String>,
+    /// Answers from resolvers that ignored the round's ECS option. Shown for
+    /// reference but excluded from `responding` — they describe the
+    /// resolver's own vantage point, not the probed client subnet, so they
+    /// must not drag the propagation percentage (or hold watch mode open)
+    /// on GeoDNS zones where their answer legitimately differs.
+    pub ecs_blind: usize,
+}
+
+/// Parameters of one query round, handed to the spawner in `main`.
+pub struct Round {
+    pub domain: String,
+    pub rtype: RecordType,
+    pub ecs: Option<ClientSubnet>,
+    pub generation: u64,
+    /// Resolver indices to (re)query.
+    pub indices: Vec<usize>,
 }
 
 pub struct App {
@@ -174,7 +193,12 @@ pub struct App {
     pub generation: u64,
     pub spinner_frame: usize,
     pub should_quit: bool,
-    pub queried: Option<(String, RecordType)>,
+    pub queried: Option<(String, RecordType, Option<ClientSubnet>)>,
+    /// Client subnets from --ecs/config, cycled with Ctrl+N. Empty for most
+    /// runs — every trace of ECS in the UI is gated on this being non-empty.
+    pub ecs_list: Vec<ClientSubnet>,
+    /// Index into `ecs_list`; None = ECS off (the plain view of the zone).
+    pub ecs_sel: Option<usize>,
     /// Table scroll offset; clamped against the viewport during draw.
     pub scroll: usize,
     /// Watch mode: re-poll after each round until propagation reaches 100%.
@@ -213,6 +237,8 @@ impl App {
             spinner_frame: 0,
             should_quit: false,
             queried: None,
+            ecs_list: Vec::new(),
+            ecs_sel: None,
             scroll: 0,
             auto_refresh: false,
             next_poll: None,
@@ -345,9 +371,36 @@ impl App {
         };
     }
 
+    /// Install the ECS list from config/CLI. Selection starts on the first
+    /// subnet — passing --ecs means "query with it", not just "have it
+    /// available".
+    pub fn set_ecs_list(&mut self, list: Vec<ClientSubnet>) {
+        self.ecs_sel = (!list.is_empty()).then_some(0);
+        self.ecs_list = list;
+    }
+
+    /// The subnet the next Enter will query with.
+    pub fn active_ecs(&self) -> Option<ClientSubnet> {
+        self.ecs_sel.map(|i| self.ecs_list[i])
+    }
+
+    /// Ctrl+N: step the selection through the configured subnets plus an
+    /// "off" position. Like Tab for the record type, this only changes the
+    /// selection — a query fires when the user presses Enter, never here.
+    pub fn cycle_ecs(&mut self) {
+        if self.ecs_list.is_empty() {
+            return;
+        }
+        self.ecs_sel = match self.ecs_sel {
+            Some(i) if i + 1 < self.ecs_list.len() => Some(i + 1),
+            Some(_) => None, // past the last subnet: ECS off
+            None => Some(0),
+        };
+    }
+
     /// Arm a new query round. Returns what to query (all resolvers), or None
     /// if the domain input is empty.
-    pub fn begin_query(&mut self) -> Option<(String, RecordType, u64, Vec<usize>)> {
+    pub fn begin_query(&mut self) -> Option<Round> {
         let domain = self.domain.trim().trim_end_matches('.').to_string();
         if domain.is_empty() {
             return None;
@@ -355,9 +408,15 @@ impl App {
         self.generation += 1;
         self.rows = vec![RowState::Pending; resolvers::active().len()];
         self.history = vec![VecDeque::new(); resolvers::active().len()];
-        self.queried = Some((domain.clone(), self.record_type()));
-        let all = (0..self.rows.len()).collect();
-        Some((domain, self.record_type(), self.generation, all))
+        let ecs = self.active_ecs();
+        self.queried = Some((domain.clone(), self.record_type(), ecs));
+        Some(Round {
+            domain,
+            rtype: self.record_type(),
+            ecs,
+            generation: self.generation,
+            indices: (0..self.rows.len()).collect(),
+        })
     }
 
     /// Arm a poll of the last-queried domain/type, ignoring the (possibly
@@ -366,8 +425,11 @@ impl App {
     /// countdown still runs (a cache can't legally change before expiry), and
     /// picked up again once it hits zero — so an old-value *majority* still
     /// gets re-checked and can flip.
-    pub fn begin_requery(&mut self) -> Option<(String, RecordType, u64, Vec<usize>)> {
-        let (domain, rtype) = self.queried.clone()?;
+    pub fn begin_requery(&mut self) -> Option<Round> {
+        // Re-polls stay on the queried round's ECS subnet even if the user
+        // has cycled the selection since — mixing subnets within one table
+        // would make the group comparison meaningless.
+        let (domain, rtype, ecs) = self.queried.clone()?;
         let summary = self.summary();
         let now = Instant::now();
         let indices: Vec<usize> = (0..self.rows.len())
@@ -392,7 +454,13 @@ impl App {
         for &i in &indices {
             self.rows[i] = RowState::Pending;
         }
-        Some((domain, rtype, self.generation, indices))
+        Some(Round {
+            domain,
+            rtype,
+            ecs,
+            generation: self.generation,
+            indices,
+        })
     }
 
     pub fn apply(&mut self, outcome: QueryOutcome) {
@@ -415,6 +483,7 @@ impl App {
             result: outcome.result,
             elapsed: outcome.elapsed,
             at: now,
+            ecs_honored: outcome.ecs_honored,
         };
     }
 
@@ -564,10 +633,28 @@ impl App {
         let mut first_seen: HashMap<&str, usize> = HashMap::new();
         let mut ok_rows: Vec<usize> = Vec::new();
         for (i, row) in self.rows.iter().enumerate() {
-            let RowState::Done { result, .. } = row else {
+            let RowState::Done {
+                result,
+                ecs_honored,
+                ..
+            } = row
+            else {
                 continue;
             };
             summary.done += 1;
+            // An answer that ignored the round's ECS option is a different
+            // question's answer: keep it out of the propagation math (see
+            // `Summary::ecs_blind`). Errors and SERVFAIL keep their normal
+            // handling — they carry no echo either way.
+            if *ecs_honored == Some(false)
+                && matches!(
+                    result,
+                    QueryResult::Records { .. } | QueryResult::NoRecords(_)
+                )
+            {
+                summary.ecs_blind += 1;
+                continue;
+            }
             match result {
                 QueryResult::Records { values, .. } => {
                     summary.ok += 1;
@@ -668,6 +755,7 @@ mod tests {
                 },
                 elapsed: Duration::from_millis(10),
                 at: Instant::now(),
+                ecs_honored: None,
             })
             .collect();
         app
@@ -712,6 +800,7 @@ mod tests {
             result: QueryResult::Error("refused".into()),
             elapsed: Duration::from_secs(3),
             at: Instant::now(),
+            ecs_honored: None,
         });
         let s = app.summary();
         assert_eq!(s.groups, 1);
@@ -747,6 +836,7 @@ mod tests {
             result: QueryResult::Error("timeout".into()),
             elapsed: Duration::from_secs(3),
             at: Instant::now(),
+            ecs_honored: None,
         });
         app.sort = SortMode::Status;
         let summary = app.summary();
@@ -933,6 +1023,7 @@ mod tests {
                     min_ttl: 60,
                 },
                 elapsed: Duration::from_millis(10),
+                ecs_honored: None,
             });
         }
         assert_eq!(app.history[0].len(), HISTORY_CAP);
@@ -943,10 +1034,10 @@ mod tests {
     #[test]
     fn requery_skips_agreeing_rows_until_their_ttl_expires() {
         let mut app = app_with_answers(&[&["new"], &["new"], &["old"]]);
-        app.queried = Some(("example.com".into(), RecordType::A));
+        app.queried = Some(("example.com".into(), RecordType::A, None));
         // Majority rows are fresh (60s TTL): only the differing row re-polls.
-        let (_, _, _, indices) = app.begin_requery().unwrap();
-        assert_eq!(indices, vec![2]);
+        let round = app.begin_requery().unwrap();
+        assert_eq!(round.indices, vec![2]);
         assert!(matches!(app.rows[2], RowState::Pending));
         assert!(matches!(app.rows[0], RowState::Done { .. }));
     }
@@ -967,10 +1058,11 @@ mod tests {
             result: QueryResult::Error("timeout".into()),
             elapsed: Duration::from_secs(3),
             at: Instant::now(),
+            ecs_honored: None,
         });
-        app.queried = Some(("example.com".into(), RecordType::A));
-        let (_, _, _, indices) = app.begin_requery().unwrap();
-        assert_eq!(indices, vec![0, 2, 3]);
+        app.queried = Some(("example.com".into(), RecordType::A, None));
+        let round = app.begin_requery().unwrap();
+        assert_eq!(round.indices, vec![0, 2, 3]);
     }
 
     #[test]
@@ -1016,6 +1108,7 @@ mod tests {
             result: QueryResult::ServFail,
             elapsed: Duration::from_millis(20),
             at: Instant::now(),
+            ecs_honored: None,
         });
         let s = app.summary();
         assert_eq!(s.servfail, 1);
@@ -1037,11 +1130,90 @@ mod tests {
                 result,
                 elapsed: Duration::from_millis(20),
                 at: Instant::now(),
+                ecs_honored: None,
             });
         }
         app.sort = SortMode::Status;
         let summary = app.summary();
         assert_eq!(app.display_order(&summary), vec![3, 2, 1, 0]);
+    }
+
+    #[test]
+    fn ecs_cycling_steps_through_subnets_and_off() {
+        let mut app = App::new("example.com".into());
+        // No list configured: Ctrl+N is inert and ECS stays off.
+        app.cycle_ecs();
+        assert_eq!(app.active_ecs(), None);
+
+        let list = vec![
+            crate::dns::parse_ecs("203.0.113.0/24").unwrap(),
+            crate::dns::parse_ecs("198.51.100.0/24").unwrap(),
+        ];
+        app.set_ecs_list(list.clone());
+        // Configuring ECS means querying with it: selection starts on the
+        // first subnet, then cycles through the rest, off, and around.
+        assert_eq!(app.active_ecs(), Some(list[0]));
+        app.cycle_ecs();
+        assert_eq!(app.active_ecs(), Some(list[1]));
+        app.cycle_ecs();
+        assert_eq!(app.active_ecs(), None);
+        app.cycle_ecs();
+        assert_eq!(app.active_ecs(), Some(list[0]));
+    }
+
+    #[test]
+    fn requery_keeps_the_queried_rounds_subnet_despite_cycling() {
+        let subnet = crate::dns::parse_ecs("203.0.113.0/24").unwrap();
+        let mut app = App::new("example.com".into());
+        app.set_ecs_list(vec![subnet]);
+        let round = app.begin_query().unwrap();
+        assert_eq!(round.ecs, Some(subnet));
+
+        // Cycling to "off" mid-watch must not switch what re-polls query:
+        // mixing subnets within one table would break the group comparison.
+        app.cycle_ecs();
+        assert_eq!(app.active_ecs(), None);
+        let round = app.begin_requery().unwrap();
+        assert_eq!(round.ecs, Some(subnet));
+        // A fresh Enter picks up the new selection.
+        let round = app.begin_query().unwrap();
+        assert_eq!(round.ecs, None);
+    }
+
+    #[test]
+    fn ecs_blind_answers_are_excluded_from_propagation() {
+        // Two resolvers honored the subnet and agree; one (e.g. Cloudflare)
+        // ignored ECS and shows its own vantage point's answer. That row
+        // must not block 100% propagation — on GeoDNS it may never match.
+        let mut app = app_with_answers(&[&["geo"], &["geo"]]);
+        for row in &mut app.rows {
+            if let RowState::Done { ecs_honored, .. } = row {
+                *ecs_honored = Some(true);
+            }
+        }
+        app.rows.push(RowState::Done {
+            result: QueryResult::Records {
+                values: vec!["other".into()],
+                min_ttl: 60,
+            },
+            elapsed: Duration::from_millis(10),
+            at: Instant::now(),
+            ecs_honored: Some(false),
+        });
+        app.rows.push(RowState::Done {
+            result: QueryResult::NoRecords("NXDomain".into()),
+            elapsed: Duration::from_millis(10),
+            at: Instant::now(),
+            ecs_honored: Some(false),
+        });
+        let s = app.summary();
+        assert_eq!(s.ecs_blind, 2);
+        assert_eq!(s.ok, 2);
+        assert_eq!(s.no_records, 0);
+        assert_eq!(s.groups, 1);
+        assert_eq!(s.responding, 2);
+        assert_eq!(s.agree, s.responding); // watch mode can complete
+        assert_eq!(s.majority_rows, vec![true, true, false, false]);
     }
 
     #[test]
@@ -1053,6 +1225,7 @@ mod tests {
             result: QueryResult::NoRecords("NXDOMAIN".into()),
             elapsed: Duration::from_millis(20),
             at: Instant::now(),
+            ecs_honored: None,
         });
         let s = app.summary();
         assert_eq!(s.responding, 3);

--- a/src/app.rs
+++ b/src/app.rs
@@ -385,8 +385,8 @@ impl App {
     }
 
     /// Ctrl+N: step the selection through the configured subnets plus an
-    /// "off" position. Like Tab for the record type, this only changes the
-    /// selection — a query fires when the user presses Enter, never here.
+    /// "off" position. The caller follows up with `begin_ecs_requery` so the
+    /// table refreshes for the new subnet without waiting for Enter.
     pub fn cycle_ecs(&mut self) {
         if self.ecs_list.is_empty() {
             return;
@@ -405,18 +405,37 @@ impl App {
         if domain.is_empty() {
             return None;
         }
+        Some(self.arm_round(domain, self.record_type()))
+    }
+
+    /// Arm a fresh round for the already-queried domain/type with the
+    /// current ECS selection: Ctrl+N re-queries as it cycles. Reads
+    /// `queried`, not the (possibly mid-edit) input field, and does nothing
+    /// before the first query — there's nothing to refresh yet.
+    pub fn begin_ecs_requery(&mut self) -> Option<Round> {
+        if self.ecs_list.is_empty() {
+            return None;
+        }
+        let (domain, rtype, _) = self.queried.clone()?;
+        Some(self.arm_round(domain, rtype))
+    }
+
+    /// Reset every row and start a round of all resolvers, capturing the
+    /// active ECS selection. History clears too: answers under a different
+    /// subnet aren't comparable across polls.
+    fn arm_round(&mut self, domain: String, rtype: RecordType) -> Round {
         self.generation += 1;
         self.rows = vec![RowState::Pending; resolvers::active().len()];
         self.history = vec![VecDeque::new(); resolvers::active().len()];
         let ecs = self.active_ecs();
-        self.queried = Some((domain.clone(), self.record_type(), ecs));
-        Some(Round {
+        self.queried = Some((domain.clone(), rtype, ecs));
+        Round {
             domain,
-            rtype: self.record_type(),
+            rtype,
             ecs,
             generation: self.generation,
             indices: (0..self.rows.len()).collect(),
-        })
+        }
     }
 
     /// Arm a poll of the last-queried domain/type, ignoring the (possibly
@@ -426,9 +445,10 @@ impl App {
     /// picked up again once it hits zero — so an old-value *majority* still
     /// gets re-checked and can flip.
     pub fn begin_requery(&mut self) -> Option<Round> {
-        // Re-polls stay on the queried round's ECS subnet even if the user
-        // has cycled the selection since — mixing subnets within one table
-        // would make the group comparison meaningless.
+        // Re-polls stay on the queried round's ECS subnet (Ctrl+N re-arms
+        // `queried` via begin_ecs_requery, so the two can't drift) — mixing
+        // subnets within one table would make the group comparison
+        // meaningless.
         let (domain, rtype, ecs) = self.queried.clone()?;
         let summary = self.summary();
         let now = Instant::now();
@@ -1169,8 +1189,9 @@ mod tests {
         let round = app.begin_query().unwrap();
         assert_eq!(round.ecs, Some(subnet));
 
-        // Cycling to "off" mid-watch must not switch what re-polls query:
-        // mixing subnets within one table would break the group comparison.
+        // If a watch poll fires between cycling and the Ctrl+N requery, it
+        // must stay on the queried round's subnet: mixing subnets within
+        // one table would break the group comparison.
         app.cycle_ecs();
         assert_eq!(app.active_ecs(), None);
         let round = app.begin_requery().unwrap();
@@ -1178,6 +1199,36 @@ mod tests {
         // A fresh Enter picks up the new selection.
         let round = app.begin_query().unwrap();
         assert_eq!(round.ecs, None);
+    }
+
+    #[test]
+    fn ctrl_n_requeries_the_queried_domain_with_the_new_subnet() {
+        let list = vec![
+            crate::dns::parse_ecs("203.0.113.0/24").unwrap(),
+            crate::dns::parse_ecs("198.51.100.0/24").unwrap(),
+        ];
+        let mut app = App::new("example.com".into());
+        app.set_ecs_list(list.clone());
+
+        // Before any query there's nothing to refresh: cycling alone.
+        app.cycle_ecs();
+        assert!(app.begin_ecs_requery().is_none());
+        app.cycle_ecs(); // back around: off
+        app.cycle_ecs(); // first subnet again
+        assert_eq!(app.active_ecs(), Some(list[0]));
+
+        let first = app.begin_query().unwrap();
+        // Ctrl+N: cycle, then a fresh full round on the *queried* domain —
+        // even while the input field is mid-edit.
+        app.insert_char('x');
+        app.cycle_ecs();
+        let round = app.begin_ecs_requery().unwrap();
+        assert_eq!(round.domain, "example.com");
+        assert_eq!(round.ecs, Some(list[1]));
+        assert!(round.generation > first.generation);
+        assert_eq!(round.indices.len(), resolvers::active().len());
+        // The new round is what re-polls now follow.
+        assert_eq!(app.queried.as_ref().unwrap().2, Some(list[1]));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
 use crate::app::ViewMode;
+use crate::dns::{self, ClientSubnet};
 use crate::resolvers::{self, Resolver};
 use crate::theme::{self, Theme};
 
@@ -26,6 +27,9 @@ pub struct Config {
     replace: bool,
     /// Preferred map panel style; the --view flag overrides it.
     view: Option<ViewMode>,
+    /// EDNS Client Subnets to query with; the --ecs flag overrides the lot.
+    #[serde(default)]
+    ecs: Vec<String>,
     #[serde(default)]
     theme: ThemeTable,
     #[serde(default)]
@@ -68,6 +72,7 @@ struct Entry {
 pub struct Settings {
     pub resolvers: Vec<Resolver>,
     pub view: Option<ViewMode>,
+    pub ecs: Vec<ClientSubnet>,
     pub theme: Theme,
 }
 
@@ -76,6 +81,7 @@ impl Settings {
         Self {
             resolvers: resolvers::defaults(),
             view: None,
+            ecs: Vec::new(),
             theme: Theme::default(),
         }
     }
@@ -105,13 +111,28 @@ pub fn load() -> Result<Settings> {
     let view = config.view;
     let theme = build_theme(std::mem::take(&mut config.theme))
         .with_context(|| format!("invalid config {}", path.display()))?;
+    let ecs = ecs_list(std::mem::take(&mut config.ecs))
+        .with_context(|| format!("invalid config {}", path.display()))?;
     let resolvers =
         resolver_list(config).with_context(|| format!("invalid config {}", path.display()))?;
     Ok(Settings {
         resolvers,
         view,
+        ecs,
         theme,
     })
+}
+
+/// Parse the `ecs` array, erroring with the offending entry so a typo'd
+/// subnet is easy to find in the file.
+fn ecs_list(entries: Vec<String>) -> Result<Vec<ClientSubnet>> {
+    entries
+        .iter()
+        .map(|entry| {
+            dns::parse_ecs(entry)
+                .map_err(|message| anyhow::anyhow!("ecs entry {entry:?}: {message}"))
+        })
+        .collect()
 }
 
 fn default_path() -> Option<PathBuf> {
@@ -349,6 +370,22 @@ mod tests {
         let chain = format!("{err:#}");
         assert!(chain.contains("theme.stale"), "{chain}");
         assert!(chain.contains("\"ornage\""), "{chain}");
+    }
+
+    #[test]
+    fn ecs_entries_parse_with_bare_ips_getting_full_prefixes() {
+        let config: Config = toml::from_str(r#"ecs = ["203.0.113.77/24", "2001:db8::1"]"#).unwrap();
+        let subnets = ecs_list(config.ecs).unwrap();
+        // Host bits zeroed, bare address gets a full-length prefix.
+        assert_eq!(dns::fmt_ecs(&subnets[0]), "203.0.113.0/24");
+        assert_eq!(dns::fmt_ecs(&subnets[1]), "2001:db8::1/128");
+    }
+
+    #[test]
+    fn bad_ecs_entry_errors_with_the_entry_text() {
+        let config: Config = toml::from_str(r#"ecs = ["10.0.0.0/33"]"#).unwrap();
+        let err = ecs_list(config.ecs).unwrap_err();
+        assert!(err.to_string().contains("10.0.0.0/33"), "{err}");
     }
 
     #[test]

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,14 +1,23 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use hickory_resolver::TokioResolver;
 use hickory_resolver::config::{NameServerConfig, ResolveHosts, ResolverConfig};
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::net::{DnsError, NetError};
-use hickory_resolver::proto::op::ResponseCode;
-use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::proto::op::{Edns, Message, Query, ResponseCode};
+use hickory_resolver::proto::rr::rdata::opt::{EdnsCode, EdnsOption};
+use hickory_resolver::proto::rr::{DNSClass, Name, RData, RecordType};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub use hickory_resolver::proto::rr::rdata::opt::ClientSubnet;
 
 const QUERY_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// EDNS UDP payload size advertised on the raw ECS path — the post-flag-day
+/// value (RFC 9715) hickory's resolver path also defaults to.
+const EDNS_PAYLOAD: u16 = 1232;
 
 #[derive(Debug, Clone)]
 pub enum QueryResult {
@@ -37,6 +46,11 @@ pub struct QueryOutcome {
     pub generation: u64,
     pub result: QueryResult,
     pub elapsed: Duration,
+    /// Some(_) only when the round carried an ECS option and the resolver
+    /// gave a real answer: whether the response echoed the option back
+    /// (RFC 7871 §7.2.2). No echo means the resolver ignored ECS — its
+    /// answer describes its own vantage point, not the probed subnet.
+    pub ecs_honored: Option<bool>,
 }
 
 /// One-server resolver going straight at `server` (no cache, single attempt)
@@ -61,14 +75,35 @@ fn build_resolver(server: IpAddr) -> Result<TokioResolver, NetError> {
 }
 
 /// Query a single upstream resolver directly (no cache, single attempt) so
-/// each server's own view of the record is what we measure.
-pub async fn query(server: IpAddr, domain: String, rtype: RecordType) -> (QueryResult, Duration) {
+/// each server's own view of the record is what we measure. With `ecs` set
+/// the query carries that client subnet and the third return value reports
+/// whether the resolver honored it (see `QueryOutcome::ecs_honored`).
+pub async fn query(
+    server: IpAddr,
+    domain: String,
+    rtype: RecordType,
+    ecs: Option<ClientSubnet>,
+) -> (QueryResult, Duration, Option<bool>) {
+    // ECS can't ride the high-level resolver (it has no per-query EDNS
+    // hook), so those queries take the raw-message path instead.
+    if let Some(subnet) = ecs {
+        let start = Instant::now();
+        let outcome = tokio::time::timeout(
+            QUERY_TIMEOUT + Duration::from_secs(1),
+            ecs_query(server, &domain, rtype, subnet),
+        )
+        .await
+        .unwrap_or((QueryResult::Error("timeout".into()), None));
+        return (outcome.0, start.elapsed(), outcome.1);
+    }
+
     let resolver = match build_resolver(server) {
         Ok(resolver) => resolver,
         Err(err) => {
             return (
                 QueryResult::Error(short_error(err.to_string())),
                 Duration::ZERO,
+                None,
             );
         }
     };
@@ -99,31 +134,207 @@ pub async fn query(server: IpAddr, domain: String, rtype: RecordType) -> (QueryR
             }
             other => QueryResult::Error(short_error(other.to_string())),
         },
-        Ok(Ok(lookup)) => {
-            let mut values: Vec<String> = Vec::new();
-            let mut min_ttl = u32::MAX;
-            for record in lookup.answers() {
-                min_ttl = min_ttl.min(record.ttl);
-                // A lookup can carry other types too (e.g. the CNAME hops on
-                // the way to an A record); label those so answers stay
-                // comparable across resolvers.
-                if record.record_type() == rtype {
-                    values.push(record.data.to_string());
-                } else {
-                    values.push(format!("{} {}", record.record_type(), record.data));
-                }
-            }
-            values.sort();
-            values.dedup();
-            if values.is_empty() {
-                QueryResult::NoRecords("empty answer".into())
-            } else {
-                QueryResult::Records { values, min_ttl }
-            }
-        }
+        Ok(Ok(lookup)) => collect_answers(lookup.answers(), rtype),
     };
 
-    (result, elapsed)
+    (result, elapsed, None)
+}
+
+/// Fold an answer section into `Records`/`NoRecords`, shared by the resolver
+/// path and the raw ECS path so both classify identically.
+fn collect_answers(
+    answers: &[hickory_resolver::proto::rr::Record],
+    rtype: RecordType,
+) -> QueryResult {
+    let mut values: Vec<String> = Vec::new();
+    let mut min_ttl = u32::MAX;
+    for record in answers {
+        min_ttl = min_ttl.min(record.ttl);
+        // A lookup can carry other types too (e.g. the CNAME hops on
+        // the way to an A record); label those so answers stay
+        // comparable across resolvers.
+        if record.record_type() == rtype {
+            values.push(record.data.to_string());
+        } else {
+            values.push(format!("{} {}", record.record_type(), record.data));
+        }
+    }
+    values.sort();
+    values.dedup();
+    if values.is_empty() {
+        QueryResult::NoRecords("empty answer".into())
+    } else {
+        QueryResult::Records { values, min_ttl }
+    }
+}
+
+/// Parse `--ecs`/config subnet syntax: `203.0.113.0/24`, `2001:db8::/56`, or
+/// a bare address (full-length prefix, like dig's +subnet). Host bits beyond
+/// the prefix are zeroed — RFC 7871 requires zero padding and some servers
+/// FORMERR on violations. Scope is always sent as 0 (§7.1.2).
+pub fn parse_ecs(s: &str) -> Result<ClientSubnet, String> {
+    let (addr, prefix) = match s.split_once('/') {
+        Some((addr, prefix)) => (
+            addr,
+            Some(
+                prefix
+                    .parse::<u8>()
+                    .map_err(|_| format!("invalid prefix length {prefix:?}"))?,
+            ),
+        ),
+        None => (s, None),
+    };
+    let addr: IpAddr = addr
+        .parse()
+        .map_err(|_| format!("invalid IP address {addr:?}"))?;
+    let max = if addr.is_ipv4() { 32 } else { 128 };
+    let prefix = prefix.unwrap_or(max);
+    if prefix > max {
+        return Err(format!("prefix /{prefix} too long for {addr} (max /{max})"));
+    }
+    let addr = match addr {
+        IpAddr::V4(v4) => {
+            let mask = (u64::MAX << (32 - u64::from(prefix))) as u32;
+            IpAddr::V4((u32::from(v4) & mask).into())
+        }
+        IpAddr::V6(v6) => {
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u128::MAX << (128 - u32::from(prefix))
+            };
+            IpAddr::V6((u128::from(v6) & mask).into())
+        }
+    };
+    Ok(ClientSubnet::new(addr, prefix, 0))
+}
+
+/// `addr/prefix` display form (`ClientSubnet` has no `Display` of its own).
+pub fn fmt_ecs(subnet: &ClientSubnet) -> String {
+    format!("{}/{}", subnet.addr(), subnet.source_prefix())
+}
+
+/// Recursive query carrying the client subnet in an EDNS OPT record.
+fn ecs_message(domain: &str, rtype: RecordType, subnet: ClientSubnet) -> Option<Message> {
+    let mut message = Message::query();
+    message.metadata.recursion_desired = true;
+    message.add_query(Query::query(Name::from_str_relaxed(domain).ok()?, rtype));
+    let mut edns = Edns::new();
+    edns.set_max_payload(EDNS_PAYLOAD);
+    edns.options_mut().insert(EdnsOption::Subnet(subnet));
+    message.edns = Some(edns);
+    Some(message)
+}
+
+/// Map a raw response to the same `QueryResult` the resolver path yields,
+/// plus whether it echoed our ECS option (RFC 7871 §7.2.2 — the echo means
+/// the resolver used the subnet; resolvers that deliberately ignore ECS,
+/// like Cloudflare or Quad9, omit it). Only real answers get an echo
+/// verdict: an error says nothing either way.
+fn classify_ecs_response(response: &Message, rtype: RecordType) -> (QueryResult, Option<bool>) {
+    let honored = response
+        .edns
+        .as_ref()
+        .is_some_and(|edns| edns.option(EdnsCode::Subnet).is_some());
+    match response.metadata.response_code {
+        ResponseCode::NoError => (collect_answers(&response.answers, rtype), Some(honored)),
+        ResponseCode::NXDomain => (
+            QueryResult::NoRecords(ResponseCode::NXDomain.to_string()),
+            Some(honored),
+        ),
+        ResponseCode::Refused => (QueryResult::Error("refused".into()), None),
+        ResponseCode::ServFail => (QueryResult::ServFail, None),
+        code => (QueryResult::Error(code.to_string()), None),
+    }
+}
+
+async fn ecs_query(
+    server: IpAddr,
+    domain: &str,
+    rtype: RecordType,
+    subnet: ClientSubnet,
+) -> (QueryResult, Option<bool>) {
+    let Some(message) = ecs_message(domain, rtype, subnet) else {
+        return (QueryResult::Error("invalid name".into()), None);
+    };
+    match exchange(server, &message).await {
+        Ok(response) => classify_ecs_response(&response, rtype),
+        Err(err) => (err, None),
+    }
+}
+
+/// One request/response exchange: UDP first, falling back to TCP when the
+/// answer comes back truncated — mirroring what the resolver path's
+/// udp_and_tcp connection pair does.
+async fn exchange(server: IpAddr, message: &Message) -> Result<Message, QueryResult> {
+    let io_err = |err: std::io::Error| QueryResult::Error(short_error(err.to_string()));
+    let request = message
+        .to_vec()
+        .map_err(|err| QueryResult::Error(short_error(err.to_string())))?;
+
+    let bind: SocketAddr = match server {
+        IpAddr::V4(_) => ([0, 0, 0, 0], 0).into(),
+        IpAddr::V6(_) => (std::net::Ipv6Addr::UNSPECIFIED, 0).into(),
+    };
+    let socket = tokio::net::UdpSocket::bind(bind).await.map_err(io_err)?;
+    // Connecting filters responses to this server's address.
+    socket.connect((server, 53)).await.map_err(io_err)?;
+    socket.send(&request).await.map_err(io_err)?;
+
+    let deadline = Instant::now() + QUERY_TIMEOUT;
+    let response = loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| QueryResult::Error("timeout".into()))?;
+        let mut buf = [0u8; 4096];
+        let len = tokio::time::timeout(remaining, socket.recv(&mut buf))
+            .await
+            .map_err(|_| QueryResult::Error("timeout".into()))?
+            .map_err(io_err)?;
+        // A stray or spoofed datagram with the wrong id: keep listening
+        // until the deadline rather than failing the query on it.
+        if let Ok(response) = Message::from_vec(&buf[..len])
+            && response.metadata.id == message.metadata.id
+        {
+            break response;
+        }
+    };
+    if !response.metadata.truncation {
+        return Ok(response);
+    }
+    // Truncated: the full answer only fits over TCP. If TCP fails too, the
+    // truncated UDP answer is still better than nothing.
+    Ok(exchange_tcp(server, &request, message.metadata.id)
+        .await
+        .unwrap_or(response))
+}
+
+async fn exchange_tcp(server: IpAddr, request: &[u8], id: u16) -> Option<Message> {
+    let mut stream =
+        tokio::time::timeout(QUERY_TIMEOUT, tokio::net::TcpStream::connect((server, 53)))
+            .await
+            .ok()?
+            .ok()?;
+    // DNS-over-TCP frames every message with a 2-byte length prefix.
+    let mut framed = Vec::with_capacity(request.len() + 2);
+    framed.extend_from_slice(&u16::try_from(request.len()).ok()?.to_be_bytes());
+    framed.extend_from_slice(request);
+    tokio::time::timeout(QUERY_TIMEOUT, stream.write_all(&framed))
+        .await
+        .ok()?
+        .ok()?;
+    let mut len_buf = [0u8; 2];
+    tokio::time::timeout(QUERY_TIMEOUT, stream.read_exact(&mut len_buf))
+        .await
+        .ok()?
+        .ok()?;
+    let mut buf = vec![0u8; usize::from(u16::from_be_bytes(len_buf))];
+    tokio::time::timeout(QUERY_TIMEOUT, stream.read_exact(&mut buf))
+        .await
+        .ok()?
+        .ok()?;
+    let response = Message::from_vec(&buf).ok()?;
+    (response.metadata.id == id).then_some(response)
 }
 
 /// IN TXT query returning each TXT character-string separately (a record's
@@ -156,10 +367,6 @@ pub async fn txt_strings(server: IpAddr, name: &str) -> Option<Vec<String>> {
 /// can't express — hand-rolled over UDP. Answers are tiny, so no truncation
 /// handling. None on any failure.
 pub async fn chaos_txt(server: IpAddr, name: &str) -> Option<Vec<String>> {
-    use hickory_resolver::proto::op::{Message, Query};
-    use hickory_resolver::proto::rr::{DNSClass, Name};
-    use std::str::FromStr;
-
     let mut query = Query::query(Name::from_str(name).ok()?, RecordType::TXT);
     query.set_query_class(DNSClass::CH);
     let mut message = Message::query();
@@ -219,7 +426,7 @@ fn short_error(message: String) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::short_error;
+    use super::*;
 
     #[test]
     fn maps_timeout_and_refused_messages() {
@@ -230,6 +437,171 @@ mod tests {
     #[test]
     fn short_messages_pass_through() {
         assert_eq!(short_error("proto error".into()), "proto error");
+    }
+
+    #[test]
+    fn parse_ecs_accepts_cidrs_and_bare_addresses() {
+        let subnet = parse_ecs("203.0.113.0/24").unwrap();
+        assert_eq!(fmt_ecs(&subnet), "203.0.113.0/24");
+        assert_eq!(subnet.scope_prefix(), 0);
+        // Bare address: full-length prefix, like dig's +subnet.
+        assert_eq!(
+            fmt_ecs(&parse_ecs("198.51.100.7").unwrap()),
+            "198.51.100.7/32"
+        );
+        assert_eq!(
+            fmt_ecs(&parse_ecs("2001:db8::1").unwrap()),
+            "2001:db8::1/128"
+        );
+        assert_eq!(
+            fmt_ecs(&parse_ecs("2001:db8::/56").unwrap()),
+            "2001:db8::/56"
+        );
+    }
+
+    #[test]
+    fn parse_ecs_zeroes_host_bits() {
+        // RFC 7871 §6: bits beyond the source prefix must be zero.
+        assert_eq!(
+            fmt_ecs(&parse_ecs("203.0.113.77/24").unwrap()),
+            "203.0.113.0/24"
+        );
+        assert_eq!(
+            fmt_ecs(&parse_ecs("10.255.255.255/20").unwrap()),
+            "10.255.240.0/20"
+        );
+        assert_eq!(fmt_ecs(&parse_ecs("192.0.2.1/0").unwrap()), "0.0.0.0/0");
+        assert_eq!(
+            fmt_ecs(&parse_ecs("2001:db8:ffff:ffff::1/56").unwrap()),
+            "2001:db8:ffff:ff00::/56"
+        );
+    }
+
+    #[test]
+    fn parse_ecs_rejects_garbage() {
+        assert!(parse_ecs("not-an-ip").unwrap_err().contains("IP address"));
+        assert!(parse_ecs("10.0.0.0/33").unwrap_err().contains("too long"));
+        assert!(
+            parse_ecs("2001:db8::/129")
+                .unwrap_err()
+                .contains("too long")
+        );
+        assert!(
+            parse_ecs("10.0.0.0/x")
+                .unwrap_err()
+                .contains("prefix length")
+        );
+        assert!(parse_ecs("").unwrap_err().contains("IP address"));
+    }
+
+    #[test]
+    fn ecs_message_carries_the_subnet_option() {
+        let subnet = parse_ecs("203.0.113.0/24").unwrap();
+        let message = ecs_message("example.com", RecordType::A, subnet).unwrap();
+        assert!(message.metadata.recursion_desired);
+        let edns = message.edns.as_ref().unwrap();
+        assert_eq!(
+            edns.option(EdnsCode::Subnet),
+            Some(&EdnsOption::Subnet(subnet))
+        );
+    }
+
+    /// A response as classify sees it: flip the id-generated query into a
+    /// response with the given code, answers, and (optionally) an ECS echo.
+    fn response(
+        code: ResponseCode,
+        answers: Vec<hickory_resolver::proto::rr::Record>,
+        echo: bool,
+    ) -> Message {
+        let mut message = Message::response(0, hickory_resolver::proto::op::OpCode::Query);
+        message.metadata.response_code = code;
+        message.answers = answers;
+        if echo {
+            let mut edns = Edns::new();
+            edns.options_mut()
+                .insert(EdnsOption::Subnet(parse_ecs("203.0.113.0/24").unwrap()));
+            message.edns = Some(edns);
+        }
+        message
+    }
+
+    fn a_record(ip: &str, ttl: u32) -> hickory_resolver::proto::rr::Record {
+        use hickory_resolver::proto::rr::rdata::A;
+        hickory_resolver::proto::rr::Record::from_rdata(
+            Name::from_str("example.com.").unwrap(),
+            ttl,
+            RData::A(A::from_str(ip).unwrap()),
+        )
+    }
+
+    #[test]
+    fn ecs_echo_detection_only_applies_to_real_answers() {
+        let (result, honored) = classify_ecs_response(
+            &response(ResponseCode::NoError, vec![a_record("192.0.2.1", 60)], true),
+            RecordType::A,
+        );
+        assert!(matches!(result, QueryResult::Records { .. }));
+        assert_eq!(honored, Some(true));
+
+        // No echo: the resolver ignored ECS (Cloudflare, Quad9, …).
+        let (_, honored) = classify_ecs_response(
+            &response(
+                ResponseCode::NoError,
+                vec![a_record("192.0.2.1", 60)],
+                false,
+            ),
+            RecordType::A,
+        );
+        assert_eq!(honored, Some(false));
+
+        let (result, honored) = classify_ecs_response(
+            &response(ResponseCode::NXDomain, vec![], false),
+            RecordType::A,
+        );
+        assert!(matches!(result, QueryResult::NoRecords(_)));
+        assert_eq!(honored, Some(false));
+
+        // Errors carry no echo verdict — they say nothing about the subnet.
+        let (result, honored) = classify_ecs_response(
+            &response(ResponseCode::Refused, vec![], false),
+            RecordType::A,
+        );
+        assert!(matches!(result, QueryResult::Error(_)));
+        assert_eq!(honored, None);
+        let (result, honored) = classify_ecs_response(
+            &response(ResponseCode::ServFail, vec![], false),
+            RecordType::A,
+        );
+        assert!(matches!(result, QueryResult::ServFail));
+        assert_eq!(honored, None);
+    }
+
+    #[test]
+    fn ecs_classification_matches_the_resolver_path() {
+        // Empty NoError answer → "empty answer", like the lookup path.
+        let (result, _) = classify_ecs_response(
+            &response(ResponseCode::NoError, vec![], true),
+            RecordType::A,
+        );
+        assert!(matches!(result, QueryResult::NoRecords(code) if code == "empty answer"));
+
+        // Min TTL across records, values sorted and deduped.
+        let answers = vec![
+            a_record("192.0.2.9", 300),
+            a_record("192.0.2.1", 60),
+            a_record("192.0.2.9", 300),
+        ];
+        let (result, _) = classify_ecs_response(
+            &response(ResponseCode::NoError, answers, true),
+            RecordType::A,
+        );
+        match result {
+            QueryResult::Records { values, min_ttl } => {
+                assert_eq!(values, vec!["192.0.2.1", "192.0.2.9"]);
+                assert_eq!(min_ttl, 60);
+            }
+            other => panic!("expected records, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,9 +258,14 @@ fn handle_key(
             app.toggle_globe();
         }
         // Ctrl+N: next client network (Ctrl+E is taken by end-of-line).
-        // Selection only — like Tab, the query fires on Enter.
+        // Cycling re-queries right away — no Enter needed to see the new
+        // subnet's answers; before the first query it just moves the chip.
         KeyCode::Char('n') if modifiers.contains(KeyModifiers::CONTROL) => {
             app.cycle_ecs();
+            if let Some(round) = app.begin_ecs_requery() {
+                app.next_poll = None;
+                spawn_round(tx, round);
+            }
         }
         KeyCode::Char('r') if modifiers.contains(KeyModifiers::CONTROL) => {
             if app.auto_refresh || app.next_poll.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use hickory_resolver::proto::rr::RecordType;
 use tokio::sync::mpsc;
 
 use app::{App, POLL_INTERVAL};
-use dns::QueryOutcome;
+use dns::{ClientSubnet, QueryOutcome};
 
 const CONFIG_HELP: &str = "\
 Configuration:
@@ -31,6 +31,8 @@ Configuration:
 
   # view = \"globe\"       # map panel style: auto (default) | map | globe
   # replace = true       # use only the resolvers below, drop the built-ins
+  # ecs = [\"203.0.113.0/24\"]  # EDNS Client Subnet(s) to query with;
+  #                      #   cycle with Ctrl+N (--ecs overrides the list)
   [[resolvers]]
   name = \"Corp DNS\"      # required
   ip = \"10.0.0.53\"       # required, IPv4 or IPv6
@@ -70,6 +72,15 @@ struct Cli {
     /// flat map on wide ones [overrides the config file's `view`]
     #[arg(long, value_enum)]
     view: Option<app::ViewMode>,
+
+    /// Query with this EDNS Client Subnet (RFC 7871) to see the zone as a
+    /// specific client network does (GeoDNS/split answers). CIDR or bare IP;
+    /// most resolvers use at most /24 (IPv4) or /56 (IPv6), and some ignore
+    /// ECS entirely (marked "no ecs"). Repeat or comma-separate to compare
+    /// several networks: Ctrl+N cycles in the TUI, --once prints every one
+    /// [overrides the config file's `ecs`]
+    #[arg(long, value_delimiter = ',', value_parser = dns::parse_ecs)]
+    ecs: Vec<ClientSubnet>,
 }
 
 fn parse_record_type(s: &str) -> Result<RecordType, String> {
@@ -93,6 +104,11 @@ async fn main() -> Result<()> {
     // error prints normally.
     let settings = config::load()?;
     let view = cli.view.or(settings.view).unwrap_or_default();
+    let ecs_list = if cli.ecs.is_empty() {
+        settings.ecs
+    } else {
+        cli.ecs
+    };
     resolvers::init(settings.resolvers);
     theme::init(settings.theme);
 
@@ -100,7 +116,7 @@ async fn main() -> Result<()> {
     // and for testing without a TTY.
     if cli.once {
         let domain = cli.domain.expect("clap enforces `requires`");
-        return run_once(domain, cli.record_type.unwrap_or(RecordType::A)).await;
+        return run_once(domain, cli.record_type.unwrap_or(RecordType::A), ecs_list).await;
     }
 
     let terminal = ratatui::init();
@@ -121,6 +137,7 @@ async fn main() -> Result<()> {
         cli.domain.unwrap_or_default(),
         cli.record_type,
         view,
+        ecs_list,
     )
     .await;
     if enhanced_keys {
@@ -135,10 +152,12 @@ async fn run_tui(
     initial_domain: String,
     initial_rtype: Option<RecordType>,
     view: app::ViewMode,
+    ecs_list: Vec<ClientSubnet>,
 ) -> Result<()> {
     let auto_query = !initial_domain.is_empty();
     let mut app = App::new(initial_domain);
     app.view_mode = view;
+    app.set_ecs_list(ecs_list);
     if let Some(rtype) = initial_rtype {
         app.rtype_idx = app::RECORD_TYPES
             .iter()
@@ -238,6 +257,11 @@ fn handle_key(
         KeyCode::Char('o') if modifiers.contains(KeyModifiers::CONTROL) => {
             app.toggle_globe();
         }
+        // Ctrl+N: next client network (Ctrl+E is taken by end-of-line).
+        // Selection only — like Tab, the query fires on Enter.
+        KeyCode::Char('n') if modifiers.contains(KeyModifiers::CONTROL) => {
+            app.cycle_ecs();
+        }
         KeyCode::Char('r') if modifiers.contains(KeyModifiers::CONTROL) => {
             if app.auto_refresh || app.next_poll.is_some() {
                 app.auto_refresh = false;
@@ -298,21 +322,21 @@ fn handle_key(
 
 /// Start a fresh query from the input field and turn watch mode on.
 fn spawn_queries(app: &mut App, tx: &mpsc::UnboundedSender<QueryOutcome>) {
-    let Some(params) = app.begin_query() else {
+    let Some(round) = app.begin_query() else {
         return;
     };
     app.auto_refresh = true;
     app.next_poll = None;
-    spawn_round(tx, params);
+    spawn_round(tx, round);
 }
 
 /// Re-poll the last-queried domain/type (watch mode).
 fn poll_query(app: &mut App, tx: &mpsc::UnboundedSender<QueryOutcome>) {
-    let Some(params) = app.begin_requery() else {
+    let Some(round) = app.begin_requery() else {
         return;
     };
     app.next_poll = None;
-    spawn_round(tx, params);
+    spawn_round(tx, round);
 }
 
 /// Ask each anycast resolver which of its sites is answering us (issue #6).
@@ -332,38 +356,37 @@ fn spawn_site_probes(site_tx: &mpsc::UnboundedSender<(usize, sites::Site)>) {
     }
 }
 
-fn spawn_round(
-    tx: &mpsc::UnboundedSender<QueryOutcome>,
-    (domain, rtype, generation, indices): (String, RecordType, u64, Vec<usize>),
-) {
-    for resolver_index in indices {
+fn spawn_round(tx: &mpsc::UnboundedSender<QueryOutcome>, round: app::Round) {
+    for resolver_index in round.indices {
         let tx = tx.clone();
-        let domain = domain.clone();
+        let domain = round.domain.clone();
+        let (rtype, ecs, generation) = (round.rtype, round.ecs, round.generation);
         let server: IpAddr = resolvers::active()[resolver_index].ip;
         tokio::spawn(async move {
-            let (result, elapsed) = dns::query(server, domain, rtype).await;
+            let (result, elapsed, ecs_honored) = dns::query(server, domain, rtype, ecs).await;
             let _ = tx.send(QueryOutcome {
                 resolver_index,
                 generation,
                 result,
                 elapsed,
+                ecs_honored,
             });
         });
     }
 }
 
-/// Plain-text single run: query every resolver once, print a table, exit.
-async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
+/// Plain-text single run: query every resolver once per configured ECS
+/// subnet (just once when there is none), print a table per round, and — the
+/// point of an ECS list — a final per-subnet convergence summary.
+async fn run_once(domain: String, rtype: RecordType, ecs_list: Vec<ClientSubnet>) -> Result<()> {
     let mut app = App::new(domain);
     app.rtype_idx = app::RECORD_TYPES
         .iter()
         .position(|t| *t == rtype)
         .unwrap_or(0);
-    let (domain, rtype, generation, indices) = app
-        .begin_query()
-        .ok_or_else(|| anyhow::anyhow!("empty domain"))?;
+    app.set_ecs_list(ecs_list);
 
-    // Site probes run concurrently with the query round.
+    // Site probes run concurrently with the first query round.
     let mut probes = tokio::task::JoinSet::new();
     for (index, resolver) in resolvers::active().iter().enumerate() {
         if let Some(probe) = resolver.probe {
@@ -372,61 +395,127 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
         }
     }
 
-    let mut tasks = tokio::task::JoinSet::new();
-    for resolver_index in indices {
-        let domain = domain.clone();
-        let server: IpAddr = resolvers::active()[resolver_index].ip;
-        tasks.spawn(async move {
-            let (result, elapsed) = dns::query(server, domain, rtype).await;
-            QueryOutcome {
-                resolver_index,
-                generation,
-                result,
-                elapsed,
+    let selections: Vec<Option<usize>> = if app.ecs_list.is_empty() {
+        vec![None]
+    } else {
+        (0..app.ecs_list.len()).map(Some).collect()
+    };
+    let multi = selections.len() > 1;
+    let mut convergence: Vec<String> = Vec::new();
+
+    for (nth, sel) in selections.into_iter().enumerate() {
+        app.ecs_sel = sel;
+        let round = app
+            .begin_query()
+            .ok_or_else(|| anyhow::anyhow!("empty domain"))?;
+
+        let mut tasks = tokio::task::JoinSet::new();
+        for resolver_index in round.indices {
+            let domain = round.domain.clone();
+            let (rtype, ecs, generation) = (round.rtype, round.ecs, round.generation);
+            let server: IpAddr = resolvers::active()[resolver_index].ip;
+            tasks.spawn(async move {
+                let (result, elapsed, ecs_honored) = dns::query(server, domain, rtype, ecs).await;
+                QueryOutcome {
+                    resolver_index,
+                    generation,
+                    result,
+                    elapsed,
+                    ecs_honored,
+                }
+            });
+        }
+        while let Some(outcome) = tasks.join_next().await {
+            app.apply(outcome?);
+        }
+        if nth == 0 {
+            while let Some(probed) = probes.join_next().await {
+                let (index, site) = probed?;
+                app.sites[index] = site;
             }
-        });
-    }
-    while let Some(outcome) = tasks.join_next().await {
-        app.apply(outcome?);
-    }
-    while let Some(probed) = probes.join_next().await {
-        let (index, site) = probed?;
-        app.sites[index] = site;
+        }
+
+        let summary = app.summary();
+        print_round(&app, &summary, multi);
+
+        if multi {
+            let subnet = round.ecs.expect("multi implies a subnet per round");
+            let answer = if summary.agree > 0 {
+                format!(
+                    "{:>2}/{} → {}",
+                    summary.agree,
+                    summary.responding,
+                    summary.majority_values.join(", ")
+                )
+            } else {
+                "no agreement".into()
+            };
+            convergence.push(format!("  {:<20} {answer}", dns::fmt_ecs(&subnet)));
+            println!();
+        }
     }
 
-    let summary = app.summary();
-    println!("{domain} {rtype}\n");
+    if multi {
+        let (domain, rtype, _) = app.queried.clone().expect("queried above");
+        println!("ecs convergence for {domain} {rtype}:");
+        for line in convergence {
+            println!("{line}");
+        }
+    }
+    Ok(())
+}
+
+/// One round's table and summary lines, in `--once`'s plain-text format.
+fn print_round(app: &App, summary: &app::Summary, multi: bool) {
+    let (domain, rtype, ecs) = app.queried.clone().expect("printed after begin_query");
+    match ecs {
+        Some(subnet) => println!("{domain} {rtype} · ecs {}\n", dns::fmt_ecs(&subnet)),
+        None => println!("{domain} {rtype}\n"),
+    }
+
     for (i, (resolver, row)) in resolvers::active().iter().zip(&app.rows).enumerate() {
         let line = match row {
             app::RowState::Done {
-                result, elapsed, ..
-            } => match result {
-                dns::QueryResult::Records { values, min_ttl } => {
-                    let status = if summary.majority_rows[i] {
-                        "OK     "
-                    } else {
-                        "DIFFERS"
-                    };
-                    format!(
-                        "{status} {:>5}ms  ttl={:<7} {}",
-                        elapsed.as_millis(),
-                        min_ttl,
-                        values.join(", ")
-                    )
+                result,
+                elapsed,
+                ecs_honored,
+                ..
+            } => {
+                // A resolver that ignored the ECS option answered for its
+                // own vantage point, not the probed subnet: shown, but
+                // marked and kept out of the propagation summary.
+                let ignored = *ecs_honored == Some(false);
+                match result {
+                    dns::QueryResult::Records { values, min_ttl } => {
+                        let status = if ignored {
+                            "NO-ECS "
+                        } else if summary.majority_rows[i] {
+                            "OK     "
+                        } else {
+                            "DIFFERS"
+                        };
+                        format!(
+                            "{status} {:>5}ms  ttl={:<7} {}",
+                            elapsed.as_millis(),
+                            min_ttl,
+                            values.join(", ")
+                        )
+                    }
+                    dns::QueryResult::NoRecords(code) => {
+                        let status = if ignored { "NO-ECS " } else { "NONE   " };
+                        format!("{status} {:>5}ms  {code}", elapsed.as_millis())
+                    }
+                    dns::QueryResult::ServFail => {
+                        format!(
+                            "FAIL    {:>5}ms  SERVFAIL (can't resolve — broken delegation or DNSSEC?)",
+                            elapsed.as_millis()
+                        )
+                    }
+                    dns::QueryResult::Error(err) => {
+                        format!("ERR     {:>5}ms  {err}", elapsed.as_millis())
+                    }
                 }
-                dns::QueryResult::NoRecords(code) => {
-                    format!("NONE    {:>5}ms  {code}", elapsed.as_millis())
-                }
-                dns::QueryResult::ServFail => {
-                    format!(
-                        "FAIL    {:>5}ms  SERVFAIL (can't resolve — broken delegation or DNSSEC?)",
-                        elapsed.as_millis()
-                    )
-                }
-                dns::QueryResult::Error(err) => {
-                    format!("ERR     {:>5}ms  {err}", elapsed.as_millis())
-                }
-            },
+            }
             _ => "??".into(),
         };
         // Anycast resolvers that identified their answering site show it
@@ -441,10 +530,14 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
         );
     }
 
-    println!(
+    let mut totals = format!(
         "\n{} of {} responding · {} servfail · {} unreachable · {} answer group(s)",
         summary.ok, summary.responding, summary.servfail, summary.errors, summary.groups
     );
+    if summary.ecs_blind > 0 {
+        totals.push_str(&format!(" · {} no-ecs", summary.ecs_blind));
+    }
+    println!("{totals}");
     if summary.agree > 0 {
         println!(
             "propagation ({}/{} responding): {}",
@@ -453,9 +546,12 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
             summary.majority_values.join(", ")
         );
     }
-    if summary.responding > 0
+    // The TTL planning note repeated per subnet would be noise: the zone's
+    // TTL doesn't change with the vantage point.
+    if !multi
+        && summary.responding > 0
         && summary.agree == summary.responding
-        && let Some(est) = app.estimated_ttl(&summary)
+        && let Some(est) = app.estimated_ttl(summary)
         && est >= app::ADVISORY_TTL
     {
         println!(
@@ -463,5 +559,4 @@ async fn run_once(domain: String, rtype: RecordType) -> Result<()> {
             app::fmt_secs(u64::from(est))
         );
     }
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,10 +261,9 @@ fn handle_key(
         // Cycling re-queries right away — no Enter needed to see the new
         // subnet's answers; before the first query it just moves the chip.
         KeyCode::Char('n') if modifiers.contains(KeyModifiers::CONTROL) => {
-            app.cycle_ecs();
-            if let Some(round) = app.begin_ecs_requery() {
-                app.next_poll = None;
-                spawn_round(tx, round);
+            if !app.ecs_list.is_empty() {
+                app.cycle_ecs();
+                requery_selection(app, tx);
             }
         }
         KeyCode::Char('r') if modifiers.contains(KeyModifiers::CONTROL) => {
@@ -279,8 +278,16 @@ fn handle_key(
             }
         }
         KeyCode::Enter => spawn_queries(app, tx),
-        KeyCode::Tab => app.cycle_record_type(true),
-        KeyCode::BackTab => app.cycle_record_type(false),
+        // Tab re-queries as it cycles, like Ctrl+N for ECS — no Enter needed
+        // to see the newly selected type's answers.
+        KeyCode::Tab => {
+            app.cycle_record_type(true);
+            requery_selection(app, tx);
+        }
+        KeyCode::BackTab => {
+            app.cycle_record_type(false);
+            requery_selection(app, tx);
+        }
         // Cmd+←/→ on macOS (reported as SUPER under the kitty keyboard
         // protocol): jump to the start/end of the input, like Home/End.
         KeyCode::Left if modifiers.contains(KeyModifiers::SUPER) => app.cursor = 0,
@@ -331,6 +338,17 @@ fn spawn_queries(app: &mut App, tx: &mpsc::UnboundedSender<QueryOutcome>) {
         return;
     };
     app.auto_refresh = true;
+    app.next_poll = None;
+    spawn_round(tx, round);
+}
+
+/// Re-run the checked domain with the current record-type/ECS selection —
+/// Tab and Ctrl+N refresh the table as they cycle; inert before the first
+/// query.
+fn requery_selection(app: &mut App, tx: &mpsc::UnboundedSender<QueryOutcome>) {
+    let Some(round) = app.begin_reselect() else {
+        return;
+    };
     app.next_poll = None;
     spawn_round(tx, round);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -28,8 +28,10 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     let complete = summary.done > 0 && !app.in_flight();
 
     let advisory = ttl_advisory(app, &summary, complete);
+    // The header grows one row for the ECS line, only when --ecs/config set
+    // subnets up — an ECS-less run renders exactly as before.
     let [header, body, footer] = Layout::vertical([
-        Constraint::Length(4),
+        Constraint::Length(if app.ecs_list.is_empty() { 4 } else { 5 }),
         Constraint::Min(6),
         Constraint::Length(if advisory.is_some() { 3 } else { 2 }),
     ])
@@ -132,25 +134,28 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
         });
         types.push(Span::raw(" "));
     }
-    // Active client subnet, only when --ecs/config set one up — an ECS-less
-    // run renders exactly as before.
+    let mut lines = vec![input, Line::from(types)];
+    // Active client subnet on its own line, only when --ecs/config set one
+    // up — an ECS-less run renders exactly as before (the header layout in
+    // `draw` reserves the extra row on the same condition).
     if !app.ecs_list.is_empty() {
-        types.push(Span::styled("· ECS: ", th.muted.style()));
+        let mut ecs = vec![Span::styled(" ECS:    ", th.muted.style())];
         match app.ecs_sel {
             Some(i) => {
-                types.push(Span::styled(
+                ecs.push(Span::styled(
                     format!(" {} ", crate::dns::fmt_ecs(&app.ecs_list[i])),
                     Style::new().fg(Color::Black).bg(th.accent).bold(),
                 ));
                 if app.ecs_list.len() > 1 {
-                    types.push(Span::styled(
+                    ecs.push(Span::styled(
                         format!(" {}/{}", i + 1, app.ecs_list.len()),
                         th.muted.style(),
                     ));
                 }
             }
-            None => types.push(Span::styled(" off ", th.muted.style())),
+            None => ecs.push(Span::styled(" off ", th.muted.style())),
         }
+        lines.push(Line::from(ecs));
     }
 
     let block = Block::default()
@@ -158,10 +163,7 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
         .border_style(Style::new().fg(th.accent))
         .title(" 🌍 DNS Propagation Checker ")
         .title_style(Style::new().bold());
-    frame.render_widget(
-        Paragraph::new(vec![input, Line::from(types)]).block(block),
-        area,
-    );
+    frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
 fn draw_gauge(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -132,6 +132,26 @@ fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
         });
         types.push(Span::raw(" "));
     }
+    // Active client subnet, only when --ecs/config set one up — an ECS-less
+    // run renders exactly as before.
+    if !app.ecs_list.is_empty() {
+        types.push(Span::styled("· ECS: ", th.muted.style()));
+        match app.ecs_sel {
+            Some(i) => {
+                types.push(Span::styled(
+                    format!(" {} ", crate::dns::fmt_ecs(&app.ecs_list[i])),
+                    Style::new().fg(Color::Black).bg(th.accent).bold(),
+                ));
+                if app.ecs_list.len() > 1 {
+                    types.push(Span::styled(
+                        format!(" {}/{}", i + 1, app.ecs_list.len()),
+                        th.muted.style(),
+                    ));
+                }
+            }
+            None => types.push(Span::styled(" off ", th.muted.style())),
+        }
+    }
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -189,6 +209,9 @@ fn draw_gauge(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
         }
         if summary.errors > 0 {
             label.push_str(&format!(" · {} unreachable", summary.errors));
+        }
+        if summary.ecs_blind > 0 {
+            label.push_str(&format!(" · {} no-ecs", summary.ecs_blind));
         }
         // Worst case, every disagreeing cache must refetch within this — the
         // number the whole watch is really about.
@@ -253,7 +276,10 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                     Cell::from(""),
                 ),
                 RowState::Done {
-                    result, elapsed, ..
+                    result,
+                    elapsed,
+                    ecs_honored,
+                    ..
                 } => {
                     let ms = elapsed.as_millis();
                     let time_style = if ms < 100 {
@@ -264,25 +290,33 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                         Style::new().fg(th.error)
                     };
                     let time = Cell::from(Span::styled(format!("{ms}ms"), time_style));
+                    // Answered without using the round's ECS option: its own
+                    // vantage point's answer, excluded from the propagation
+                    // math, so agree/differ verdicts don't apply to it.
+                    let ecs_ignored = *ecs_honored == Some(false);
                     match result {
                         QueryResult::Records { values, min_ttl } => {
                             let matches_majority = !complete || summary.majority_rows[i];
-                            let verdict = if matches_majority {
+                            let verdict = if matches_majority || ecs_ignored {
                                 None
                             } else {
                                 app.ttl_verdict(i, now)
                             };
-                            let (status, style) = match verdict {
-                                Some(TtlVerdict::PastTtl) => {
-                                    ("! PAST TTL", Style::new().fg(th.stale).bold())
+                            let (status, style) = if ecs_ignored {
+                                ("◌ NO ECS", th.muted.style())
+                            } else {
+                                match verdict {
+                                    Some(TtlVerdict::PastTtl) => {
+                                        ("! PAST TTL", Style::new().fg(th.stale).bold())
+                                    }
+                                    Some(TtlVerdict::Upstream) => {
+                                        ("↻ UPSTREAM", Style::new().fg(th.upstream).bold())
+                                    }
+                                    None if matches_majority => {
+                                        ("✓ OK", Style::new().fg(th.agree).bold())
+                                    }
+                                    None => ("≠ DIFFERS", Style::new().fg(th.differ).bold()),
                                 }
-                                Some(TtlVerdict::Upstream) => {
-                                    ("↻ UPSTREAM", Style::new().fg(th.upstream).bold())
-                                }
-                                None if matches_majority => {
-                                    ("✓ OK", Style::new().fg(th.agree).bold())
-                                }
-                                None => ("≠ DIFFERS", Style::new().fg(th.differ).bold()),
                             };
                             // Live countdown to the moment this cache entry
                             // must be refetched. For disagreeing rows this is
@@ -291,7 +325,7 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                             let remaining = state.remaining_ttl(now).unwrap_or_default().as_secs();
                             let exp = if remaining == 0 {
                                 Span::styled("expired", th.muted.style().italic())
-                            } else if matches_majority {
+                            } else if matches_majority || ecs_ignored {
                                 Span::styled(fmt_secs(remaining), th.muted.style())
                             } else {
                                 Span::styled(fmt_secs(remaining), style)
@@ -303,7 +337,7 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                                 Cell::from(Span::styled(status, style)),
                                 Cell::from(Span::styled(
                                     values.join(", "),
-                                    if matches_majority {
+                                    if matches_majority || ecs_ignored {
                                         Style::new()
                                     } else {
                                         Style::new().fg(style.fg.unwrap_or(th.differ))
@@ -311,13 +345,27 @@ fn draw_table(frame: &mut Frame, app: &App, summary: &Summary, complete: bool, a
                                 )),
                             )
                         }
-                        QueryResult::NoRecords(code) => (
-                            time,
-                            Cell::from(""),
-                            Cell::from(""),
-                            Cell::from(Span::styled("∅ NONE", Style::new().fg(th.error).bold())),
-                            Cell::from(Span::styled(code.clone(), Style::new().fg(th.error))),
-                        ),
+                        QueryResult::NoRecords(code) => {
+                            let (status, style) = if ecs_ignored {
+                                ("◌ NO ECS", th.muted.style())
+                            } else {
+                                ("∅ NONE", Style::new().fg(th.error).bold())
+                            };
+                            (
+                                time,
+                                Cell::from(""),
+                                Cell::from(""),
+                                Cell::from(Span::styled(status, style)),
+                                Cell::from(Span::styled(
+                                    code.clone(),
+                                    if ecs_ignored {
+                                        th.muted.style()
+                                    } else {
+                                        Style::new().fg(th.error)
+                                    },
+                                )),
+                            )
+                        }
                         QueryResult::ServFail => (
                             time,
                             Cell::from(""),
@@ -506,6 +554,13 @@ fn draw_map(
                     // the whole muted style instead of an fg like the rest.
                     RowState::Idle => th.muted.style(),
                     RowState::Pending => Style::new().fg(th.pending),
+                    // ECS-ignoring resolvers answered a different question
+                    // than the probed subnet: muted like idle, not judged.
+                    RowState::Done {
+                        result: QueryResult::Records { .. } | QueryResult::NoRecords(_),
+                        ecs_honored: Some(false),
+                        ..
+                    } => th.muted.style(),
                     RowState::Done { result, .. } => Style::new().fg(match result {
                         QueryResult::Records { .. } => {
                             if !complete || summary.majority_rows[i] {
@@ -534,14 +589,18 @@ fn draw_map_info(frame: &mut Frame, app: &App, summary: &Summary, complete: bool
         return;
     }
     let th = theme::active();
-    let mut lines = vec![Line::from(vec![
+    let mut legend = vec![
         Span::styled("● agrees  ", Style::new().fg(th.agree)),
         Span::styled("● differs  ", Style::new().fg(th.differ)),
         Span::styled("● past-ttl  ", Style::new().fg(th.stale)),
         Span::styled("● upstream  ", Style::new().fg(th.upstream)),
         Span::styled("● error  ", Style::new().fg(th.error)),
         Span::styled("● pending", Style::new().fg(th.pending)),
-    ])];
+    ];
+    if !app.ecs_list.is_empty() {
+        legend.push(Span::styled("  ● no-ecs", th.muted.style()));
+    }
+    let mut lines = vec![Line::from(legend)];
     if complete && !summary.majority_values.is_empty() {
         lines.push(Line::default());
         lines.push(Line::from(Span::styled(
@@ -585,9 +644,15 @@ fn draw_footer(
 ) {
     let th = theme::active();
     let mut status = Line::default();
-    if let Some((domain, rtype)) = &app.queried {
+    if let Some((domain, rtype, ecs)) = &app.queried {
+        // Name the round's subnet: cycling the selection doesn't re-query,
+        // so the table may show a different subnet than the header chip.
+        let ecs = match ecs {
+            Some(subnet) => format!(" ecs {}", crate::dns::fmt_ecs(subnet)),
+            None => String::new(),
+        };
         status.push_span(Span::styled(
-            format!(" {domain} {rtype}: "),
+            format!(" {domain} {rtype}{ecs}: "),
             Style::new().bold(),
         ));
         status.push_span(Span::styled(
@@ -618,9 +683,23 @@ fn draw_footer(
                 th.muted.style()
             },
         ));
+        if summary.ecs_blind > 0 {
+            status.push_span(Span::raw(" · "));
+            status.push_span(Span::styled(
+                format!("{} no-ecs", summary.ecs_blind),
+                th.muted.style(),
+            ));
+        }
     }
+    let ecs_hint = if app.ecs_list.is_empty() {
+        ""
+    } else {
+        " · Ctrl+N ecs"
+    };
     let keys = Line::from(Span::styled(
-        " type to edit · ←/→ move cursor (⌥/Ctrl word, ⌘/Home/End ends) · Enter query+watch · Ctrl+R watch on/off · Ctrl+S sort · Ctrl+O globe/map · Tab record type · ↑/↓ scroll · Esc quit",
+        format!(
+            " type to edit · ←/→ move cursor (⌥/Ctrl word, ⌘/Home/End ends) · Enter query+watch · Ctrl+R watch on/off · Ctrl+S sort · Ctrl+O globe/map · Tab record type{ecs_hint} · ↑/↓ scroll · Esc quit"
+        ),
         th.muted.style(),
     ));
     if let Some(advisory) = advisory {


### PR DESCRIPTION
Closes #14.

## What

`--ecs <subnet>` (or `ecs = [...]` in the config file, flag overrides) attaches an EDNS Client Subnet option ([RFC 7871](https://datatracker.ietf.org/doc/html/rfc7871)) to every query, so GeoDNS zones answer for that client network instead of each resolver's own vantage point. Subnets are CIDRs or bare IPs (bare = full-length prefix, like `dig +subnet`); host bits beyond the prefix are zeroed as the RFC requires, and several subnets can be given to compare how answers converge across client networks (the issue's ask).

- **TUI**: the header gains an ECS line below the record types showing the active subnet; **Ctrl+N** cycles through the configured subnets plus an *off* position and immediately re-queries the checked domain with the new subnet (before the first query it just moves the selection); Tab/Shift-Tab re-query the same way when cycling record types. Re-polls stay on the queried round's subnet. With no ECS configured, the UI is unchanged — no chip, no hint, no legend entry.
- **`--once`**: one table per subnet, then a per-subnet convergence summary (`subnet → agree/responding → majority answer`).
- **ECS-ignoring resolvers**: RFC 7871 §7.2.2 says a resolver that used ECS echoes the option back. No echo (Cloudflare, Quad9, … ignore ECS by policy) tags the row `◌ NO ECS` / `NO-ECS`: the answer stays visible for reference but is excluded from the propagation percentage — it describes the resolver's own location, not the probed network, and on GeoDNS zones it may legitimately never match, which would otherwise hold watch mode open forever.

## How

The high-level hickory resolver has no per-query EDNS hook (`DnsRequestOptions` has a literal `// TODO: add EDNS options here?`), so ECS queries take a raw-message path in `dns.rs` — precedent: `chaos_txt` already hand-rolls a query. A hand-built message carries the subnet in its OPT record (payload 1232, matching the resolver path), goes out over UDP with a TCP retry on truncation, and is classified into the same `QueryResult` variants via a `collect_answers` helper now shared with the resolver path. The ECS echo verdict only applies to real answers (`Records`/`NoRecords`); REFUSED/SERVFAIL/timeouts keep their existing handling.

State-wise, `begin_query` captures the active subnet into the round (a new `app::Round` struct replaces the growing tuple), `RowState::Done` carries the per-row echo verdict, and `Summary` gains an `ecs_blind` count that the gauge, footer, and `--once` totals surface.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (84 tests, 11 new: subnet parsing/zeroing, message building, response classification incl. echo detection, cycling incl. off-position, requery pinning, summary exclusion, config parsing/errors).
- **End-to-end `--once`**: `dnsglobe www.google.com --once --ecs 24.48.0.0/16,1.144.0.0/16` prints two tables and the convergence summary; ECS-aware resolvers (Google, Lumen, Neustar, AdGuard, AliDNS, …) show `OK`, ignorers (Cloudflare, Quad9, OpenDNS, …) show `NO-ECS`, and the totals line counts them (`… · 21 no-ecs`). Reserved ranges surface resolver policy verbatim (8.8.8.8 REFUSES martian ECS prefixes like TEST-NET, shown as `ERR refused`).
- **End-to-end TUI (expect/PTY)**: header chip + `1/2` position, Ctrl+N cycles second subnet → off → wraps back, footer hint present; a live round shows `◌ NO ECS` rows, the round's subnet in the status line, and the settled `no-ecs` count; an ECS-less run draws byte-identical UI (asserted no `ECS`/`Ctrl+N` text anywhere).
- **Config file**: `ecs = ["24.48.0.0/16"]` via `DNSGLOBE_CONFIG` works; a bad entry fails at startup with `ecs entry "10.0.0.0/33": prefix /33 too long for 10.0.0.0 (max /32)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


