### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-11
+
 ### Added
 
 - Resolvers can be added and removed at runtime: `+` opens an add-resolver
@@ -189,7 +191,8 @@ Initial release.
   that re-polls every 30s until all responding resolvers agree.
 - `--once` plain-text mode for scripts.
 
-[Unreleased]: https://github.com/514-labs/dnsglobe/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/514-labs/dnsglobe/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/514-labs/dnsglobe/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/514-labs/dnsglobe/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/514-labs/dnsglobe/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/514-labs/dnsglobe/compare/v0.1.1...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "dnsglobe"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnsglobe"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal"

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,8 @@
         pkgs = nixpkgs.legacyPackages.${system};
         dnsglobe = pkgs.rustPlatform.buildRustPackage {
           pname = "dnsglobe";
-          version = "0.3.0";
+          # Track Cargo.toml so version-bump PRs don't have to touch the flake.
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
           nativeBuildInputs = [ pkgs.pkg-config ];


### PR DESCRIPTION
Version-bump PR cutting 0.4.0, per the release process in AGENTS.md:

- `Cargo.toml` 0.3.1 → 0.4.0, `Cargo.lock` refreshed via `cargo check`
- `CHANGELOG.md`: `[Unreleased]` renamed to `[0.4.0] - 2026-07-11` with a fresh empty `[Unreleased]` above, compare links updated
- `flake.nix` no longer hardcodes the version (it still said "0.3.0"): it now reads it from `Cargo.toml`, so `nix run github:514-labs/dnsglobe/v0.4.0` reports the right version and future release PRs never touch the flake

0.4.0 ships: runtime resolver add/remove (#30), EDNS Client Subnet support (#29), the 3D rotating globe view with responsive map/globe switching (#26), theme-safe default colors plus a configurable `[theme]` table (#27), and Nix flake / Devbox support (#21).

Merging this PR triggers `tag-release.yml`, which builds binaries, publishes to crates.io and Homebrew, and creates the `v0.4.0` tag and GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)