### PR TITLE
Query names with mid-label underscores instead of rejecting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Names with an underscore in the middle of a label are queried instead of
+  failing on every resolver with `protocol error: Label contains invalid
+  character`. Underscores are legal anywhere in a DNS label — the
+  letter-digit-hyphen rule is about *hostnames*, not the DNS wire format — so
+  the delegated SPF/DMARC hosts that EasyDMARC, Valimail and friends generate
+  (`_spf.514_ax._d.example.com`) now resolve like they do in `dig`. Default
+  and `--ecs` runs accept exactly the same set of names; previously only
+  `--ecs` handled these.
+  ([#34](https://github.com/514-labs/dnsglobe/issues/34),
+  [#XX](https://github.com/514-labs/dnsglobe/pull/XX))
+- A domain that really is malformed (an empty label, a label over 63
+  characters) is now reported once — as a startup error for a name given on
+  the command line, or in place of the propagation gauge for one typed in the
+  TUI — instead of filling the table with one identical error per resolver,
+  which read like a network outage.
+  ([#XX](https://github.com/514-labs/dnsglobe/pull/XX))
+
 ## [0.4.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `--ecs` runs accept exactly the same set of names; previously only
   `--ecs` handled these.
   ([#34](https://github.com/514-labs/dnsglobe/issues/34),
-  [#XX](https://github.com/514-labs/dnsglobe/pull/XX))
+  [#37](https://github.com/514-labs/dnsglobe/pull/37))
 - A domain that really is malformed (an empty label, a label over 63
   characters) is now reported once — as a startup error for a name given on
   the command line, or in place of the propagation gauge for one typed in the
   TUI — instead of filling the table with one identical error per resolver,
   which read like a network outage.
-  ([#XX](https://github.com/514-labs/dnsglobe/pull/XX))
+  ([#37](https://github.com/514-labs/dnsglobe/pull/37))
 
 ## [0.4.0] - 2026-07-11
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use hickory_resolver::proto::rr::RecordType;
 
-use crate::dns::{ClientSubnet, QueryOutcome, QueryResult};
+use crate::dns::{self, ClientSubnet, QueryOutcome, QueryResult};
 use crate::globe::GlobeView;
 use crate::resolvers::{self, Resolver};
 use crate::sites::Site;
@@ -307,6 +307,21 @@ impl ResolverForm {
     }
 }
 
+/// Normalize a typed-or-passed domain and check that it is a name we can put
+/// on the wire: trailing whitespace and the root dot go (`example.com.` and
+/// `example.com` are the same name), then `dns::parse_name` has the final
+/// say. Shared by the CLI and the TUI input field so both modes accept
+/// exactly the same set of names, and so a malformed one is reported once
+/// rather than as an identical failure on every resolver. An empty input is
+/// "nothing to query", not an error — callers treat it as a no-op.
+pub fn validate_domain(input: &str) -> Result<String, String> {
+    let domain = input.trim().trim_end_matches('.').to_string();
+    if !domain.is_empty() {
+        dns::parse_name(&domain)?;
+    }
+    Ok(domain)
+}
+
 pub struct App {
     pub domain: String,
     /// Cursor position in `domain`. The input only accepts ASCII
@@ -357,6 +372,11 @@ pub struct App {
     pub selected: Option<usize>,
     /// Add-resolver dialog; while open it captures all key input.
     pub form: Option<ResolverForm>,
+    /// Why the last Enter didn't start a round: the input isn't a DNS name.
+    /// Shown in place of the gauge and cleared by the next edit — firing the
+    /// round anyway would fill the table with 30-odd identical parse errors
+    /// that read like a network outage.
+    pub input_error: Option<String>,
 }
 
 impl App {
@@ -386,6 +406,7 @@ impl App {
             resolvers,
             selected: None,
             form: None,
+            input_error: None,
         }
     }
 
@@ -542,18 +563,21 @@ impl App {
     pub fn insert_char(&mut self, c: char) {
         self.domain.insert(self.cursor, c);
         self.cursor += 1;
+        self.input_error = None;
     }
 
     pub fn backspace(&mut self) {
         if self.cursor > 0 {
             self.cursor -= 1;
             self.domain.remove(self.cursor);
+            self.input_error = None;
         }
     }
 
     pub fn delete(&mut self) {
         if self.cursor < self.domain.len() {
             self.domain.remove(self.cursor);
+            self.input_error = None;
         }
     }
 
@@ -592,6 +616,7 @@ impl App {
     pub fn clear_domain(&mut self) {
         self.domain.clear();
         self.cursor = 0;
+        self.input_error = None;
     }
 
     /// The view this width calls for under the active policy.
@@ -665,9 +690,18 @@ impl App {
     }
 
     /// Arm a new query round. Returns what to query (all resolvers), or None
-    /// if the domain input is empty.
+    /// if the domain input is empty or isn't a DNS name — the latter leaves
+    /// `input_error` set for the header to show, and the previous round's
+    /// rows untouched.
     pub fn begin_query(&mut self) -> Option<Round> {
-        let domain = self.domain.trim().trim_end_matches('.').to_string();
+        let domain = match validate_domain(&self.domain) {
+            Ok(domain) => domain,
+            Err(err) => {
+                self.input_error = Some(err);
+                return None;
+            }
+        };
+        self.input_error = None;
         if domain.is_empty() {
             return None;
         }
@@ -1043,6 +1077,60 @@ mod tests {
             })
             .collect();
         app
+    }
+
+    #[test]
+    fn underscored_names_are_queryable() {
+        // Issue #34: an underscore anywhere in a label is legal on the wire,
+        // so these must reach the resolvers instead of failing to parse.
+        for input in [
+            "foo_bar.example.com",
+            "_dmarc.514.ax",
+            "_spf.514_ax._d.easydmarc.pro",
+        ] {
+            let mut app = App::new(input.into());
+            let round = app.begin_query().expect("should arm a round");
+            assert_eq!(round.domain, input);
+            assert_eq!(app.input_error, None);
+        }
+    }
+
+    #[test]
+    fn validate_domain_normalizes_input() {
+        // The root dot and stray whitespace are noise, not part of the name.
+        assert_eq!(validate_domain("  example.com. ").unwrap(), "example.com");
+        // Empty input is a no-op, not an error.
+        assert_eq!(validate_domain("   ").unwrap(), "");
+    }
+
+    #[test]
+    fn malformed_name_is_reported_once_and_queries_nothing() {
+        let mut app = App::new("a..b.example.com".into());
+        assert!(app.begin_query().is_none());
+        // One user-facing message, and no round — so no table full of
+        // identical per-resolver parse errors.
+        assert!(app.input_error.is_some());
+        assert_eq!(app.generation, 0);
+        assert!(app.rows.iter().all(|row| matches!(row, RowState::Idle)));
+        assert!(app.queried.is_none());
+
+        // Editing the input clears the complaint, and a valid name arms a
+        // round again.
+        app.backspace();
+        assert_eq!(app.input_error, None);
+        app.clear_domain();
+        for c in "example.com".chars() {
+            app.insert_char(c);
+        }
+        assert!(app.begin_query().is_some());
+        assert_eq!(app.input_error, None);
+    }
+
+    #[test]
+    fn empty_input_is_not_an_error() {
+        let mut app = App::new(String::new());
+        assert!(app.begin_query().is_none());
+        assert_eq!(app.input_error, None);
     }
 
     #[test]

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -53,6 +53,20 @@ pub struct QueryOutcome {
     pub ecs_honored: Option<bool>,
 }
 
+/// Parse user input into a queryable name.
+///
+/// Underscores are legal in a DNS label wherever they appear, not only at
+/// the start: letter-digit-hyphen is a *hostname* rule (RFC 952, RFC 1123
+/// §2.1), while the wire format (RFC 1035 §3.1) treats a label as opaque
+/// octets. Real zones lean on that — the delegated SPF/DMARC hosts that
+/// EasyDMARC and friends hand out look like `_spf.514_ax._d.example.com`.
+/// hickory's `IntoName for &str` goes through the strict `Name::from_str`,
+/// which enforces the hostname rule, so every query path parses relaxed
+/// here instead and hands the resulting `Name` to the resolver.
+pub fn parse_name(domain: &str) -> Result<Name, String> {
+    Name::from_str_relaxed(domain).map_err(|err| err.to_string())
+}
+
 /// One-server resolver going straight at `server` (no cache, single attempt)
 /// so that server's own view of a record is what we measure.
 fn build_resolver(server: IpAddr) -> Result<TokioResolver, NetError> {
@@ -84,13 +98,22 @@ pub async fn query(
     rtype: RecordType,
     ecs: Option<ClientSubnet>,
 ) -> (QueryResult, Duration, Option<bool>) {
+    // Parsed once here so both paths agree on what is queryable. Callers
+    // validate the name up front (a malformed one is a user error worth
+    // reporting once, not 34 identical row failures), so this arm is a
+    // backstop.
+    let name = match parse_name(&domain) {
+        Ok(name) => name,
+        Err(err) => return (QueryResult::Error(short_error(err)), Duration::ZERO, None),
+    };
+
     // ECS can't ride the high-level resolver (it has no per-query EDNS
     // hook), so those queries take the raw-message path instead.
     if let Some(subnet) = ecs {
         let start = Instant::now();
         let outcome = tokio::time::timeout(
             QUERY_TIMEOUT + Duration::from_secs(1),
-            ecs_query(server, &domain, rtype, subnet),
+            ecs_query(server, name, rtype, subnet),
         )
         .await
         .unwrap_or((QueryResult::Error("timeout".into()), None));
@@ -111,7 +134,7 @@ pub async fn query(
     let start = Instant::now();
     let lookup = tokio::time::timeout(
         QUERY_TIMEOUT + Duration::from_secs(1),
-        resolver.lookup(domain.as_str(), rtype),
+        resolver.lookup(name, rtype),
     )
     .await;
     let elapsed = start.elapsed();
@@ -215,15 +238,15 @@ pub fn fmt_ecs(subnet: &ClientSubnet) -> String {
 }
 
 /// Recursive query carrying the client subnet in an EDNS OPT record.
-fn ecs_message(domain: &str, rtype: RecordType, subnet: ClientSubnet) -> Option<Message> {
+fn ecs_message(name: Name, rtype: RecordType, subnet: ClientSubnet) -> Message {
     let mut message = Message::query();
     message.metadata.recursion_desired = true;
-    message.add_query(Query::query(Name::from_str_relaxed(domain).ok()?, rtype));
+    message.add_query(Query::query(name, rtype));
     let mut edns = Edns::new();
     edns.set_max_payload(EDNS_PAYLOAD);
     edns.options_mut().insert(EdnsOption::Subnet(subnet));
     message.edns = Some(edns);
-    Some(message)
+    message
 }
 
 /// Map a raw response to the same `QueryResult` the resolver path yields,
@@ -250,13 +273,11 @@ fn classify_ecs_response(response: &Message, rtype: RecordType) -> (QueryResult,
 
 async fn ecs_query(
     server: IpAddr,
-    domain: &str,
+    name: Name,
     rtype: RecordType,
     subnet: ClientSubnet,
 ) -> (QueryResult, Option<bool>) {
-    let Some(message) = ecs_message(domain, rtype, subnet) else {
-        return (QueryResult::Error("invalid name".into()), None);
-    };
+    let message = ecs_message(name, rtype, subnet);
     match exchange(server, &message).await {
         Ok(response) => classify_ecs_response(&response, rtype),
         Err(err) => (err, None),
@@ -495,9 +516,45 @@ mod tests {
     }
 
     #[test]
+    fn parse_name_accepts_underscores_anywhere() {
+        // Underscores are a wire-format non-issue (RFC 1035 §3.1); only the
+        // *hostname* rules forbid them. Leading ones (`_dmarc`) always
+        // worked; mid-label ones are what issue #34 was about.
+        assert_eq!(
+            parse_name("_dmarc.514.ax").unwrap().to_string(),
+            "_dmarc.514.ax"
+        );
+        assert_eq!(
+            parse_name("foo_bar.example.com").unwrap().to_string(),
+            "foo_bar.example.com"
+        );
+        // A delegated SPF host, the shape that motivated the fix.
+        assert_eq!(
+            parse_name("_spf.514_ax._d.easydmarc.pro")
+                .unwrap()
+                .to_string(),
+            "_spf.514_ax._d.easydmarc.pro"
+        );
+        // Ordinary names and a trailing root dot still parse.
+        assert_eq!(
+            parse_name("foo-bar.example.com.").unwrap().to_string(),
+            "foo-bar.example.com."
+        );
+    }
+
+    #[test]
+    fn parse_name_rejects_malformed_names() {
+        // An empty label and a label over the 63-octet limit are wire-format
+        // violations, so relaxed parsing still turns them down.
+        assert!(parse_name("a..b.example.com").is_err());
+        assert!(parse_name(&format!("{}.com", "a".repeat(64))).is_err());
+        assert!(parse_name("ex@mple.com").is_err());
+    }
+
+    #[test]
     fn ecs_message_carries_the_subnet_option() {
         let subnet = parse_ecs("203.0.113.0/24").unwrap();
-        let message = ecs_message("example.com", RecordType::A, subnet).unwrap();
+        let message = ecs_message(parse_name("example.com").unwrap(), RecordType::A, subnet);
         assert!(message.metadata.recursion_desired);
         let edns = message.edns.as_ref().unwrap();
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,10 +112,21 @@ async fn main() -> Result<()> {
     resolvers::init(settings.resolvers);
     theme::init(settings.theme);
 
+    // A name that can't go on the wire is a user error, so say so once here —
+    // before the terminal enters raw mode — instead of letting every resolver
+    // report the same parse failure and look like a network outage.
+    let domain = cli
+        .domain
+        .map(|domain| {
+            app::validate_domain(&domain)
+                .map_err(|err| anyhow::anyhow!("invalid domain name {domain:?}: {err}"))
+        })
+        .transpose()?;
+
     // `--once` runs a single check and prints plain text — handy for scripts
     // and for testing without a TTY.
     if cli.once {
-        let domain = cli.domain.expect("clap enforces `requires`");
+        let domain = domain.expect("clap enforces `requires`");
         return run_once(domain, cli.record_type.unwrap_or(RecordType::A), ecs_list).await;
     }
 
@@ -134,7 +145,7 @@ async fn main() -> Result<()> {
     }
     let result = run_tui(
         terminal,
-        cli.domain.unwrap_or_default(),
+        domain.unwrap_or_default(),
         cli.record_type,
         view,
         ecs_list,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -171,6 +171,17 @@ fn draw_gauge(frame: &mut Frame, app: &App, summary: &Summary, area: Rect) {
     let th = theme::active();
     let total = app.resolvers.len();
 
+    // Enter on something that isn't a DNS name never started a round, so the
+    // gauge below would be stale (or absent): say why instead.
+    if let Some(err) = &app.input_error {
+        let message = Paragraph::new(Line::from(vec![
+            Span::styled("  not a domain name: ", Style::new().fg(th.error).bold()),
+            Span::styled(err.as_str(), Style::new().fg(th.error)),
+        ]));
+        frame.render_widget(message, area);
+        return;
+    }
+
     if app.queried.is_none() {
         let hint = Paragraph::new(Line::from(Span::styled(
             "  type a domain and press Enter",


### PR DESCRIPTION
Fixes #34.

## The problem

Any name with an underscore outside a leading position was rejected before a
single packet went out — every resolver reported the same
`protocol error: Label contains invalid character`, which reads like a network
outage rather than a parse failure. That put a large class of real records out
of reach, notably the delegated SPF/DMARC hosts EasyDMARC, Valimail and friends
generate (`_spf.514_ax._d.easydmarc.pro`).

Underscores are legal anywhere in a DNS label: letter-digit-hyphen is a
*hostname* rule (RFC 952, RFC 1123 §2.1), not a DNS wire-format rule
(RFC 1035 §3.1). The cause was `src/dns.rs`'s default path calling
`resolver.lookup(domain.as_str(), rtype)` — passing a `&str` goes through
hickory's `IntoName`, which runs the strict `Name::from_str` and enforces the
hostname rule. The `--ecs` path already used `Name::from_str_relaxed`, so the
two modes disagreed about what was queryable.

## How it works

**`src/dns.rs`** — new `pub fn parse_name(&str) -> Result<Name, String>` wrapping
`Name::from_str_relaxed`, with a comment on the RFC distinction. `query()` parses
once at the top and hands the resulting `Name` to both paths: `resolver.lookup(name, rtype)`
on the default path and `ecs_message(name, …)` on the ECS path. `ecs_message` /
`ecs_query` now take a `Name` and no longer return `Option`, since parsing moved
upstream. Default and `--ecs` runs therefore accept exactly the same set of names.

**`src/app.rs`** — new free fn `validate_domain(input) -> Result<String, String>`
that normalizes (trim + strip the root dot) then parses; shared by the CLI and the
TUI input field. New `App::input_error: Option<String>`; `begin_query` sets it and
returns `None` on a malformed name — no generation bump, no `queried`, rows
untouched — and the input-editing methods clear it. Empty input stays a silent
no-op rather than an error.

**`src/main.rs`** — the CLI domain is validated once, before `ratatui::init()`, so
both `--once` and watch mode fail with one plain-text error instead of launching
into a broken run.

**`src/ui.rs`** — `draw_gauge` renders `input_error` in the error color in place of
the gauge when set.

Net effect: a genuinely malformed name is reported once, up front, instead of 34
identical per-resolver ERR rows.

### Design notes

- A typo'd CLI argument is better reported in plain text than inside a TUI the user
  must then quit, so watch mode exits early too rather than opening with the bad
  name in the box.
- Typing a bad name in the TUI and hitting Enter shows the message and leaves the
  previous table intact — zero bogus ERR rows.
- No new key binding, so the footer hint line is unchanged.
- Out of scope: `chaos_txt` / `txt_strings`, which use fixed internal probe names
  (`id.server`), and hickory's other relaxed-parser quirks (it still rejects a
  leading `-` in a label).

## Tests

New unit tests, in the `#[cfg(test)] mod tests` of the same files:

- `dns::parse_name_accepts_underscores_anywhere` — mid-label, leading, the
  easydmarc shape, and a trailing root dot
- `dns::parse_name_rejects_malformed_names` — empty label, 64-octet label, `@`
- `app::underscored_names_are_queryable`
- `app::validate_domain_normalizes_input`
- `app::malformed_name_is_reported_once_and_queries_nothing`
- `app::empty_input_is_not_an_error`

## Verification

Quality gates (what CI runs):

```
cargo fmt --check                         → clean
cargo clippy --all-targets -- -D warnings → clean
cargo test                                → 103 passed; 0 failed
```

### `cargo run -- foo_bar.example.com --once TXT`

The repro from the issue. Every resolver now queries; no parse error anywhere:

```
foo_bar.example.com TXT

Google Public DNS      →YUL     8.8.8.8          NONE       28ms  No Error
Cloudflare             →YUL     1.1.1.1          NONE       22ms  No Error
Quad9                  →YUL     9.9.9.9          NONE       20ms  No Error
...
Bezeq Intl             IL       192.115.106.10   ERR       306ms  refused
...
0 of 33 responding · 0 servfail · 1 unreachable · 0 answer group(s)
```

### `cargo run -- _spf.514_ax._d.easydmarc.pro --once TXT`

The real-world delegated SPF host — real TXT answers, converging:

```
Google Public DNS  →YUL  8.8.8.8  OK  23ms  ttl=300  v=spf1 ip4:74.125.0.0/16 ip4:209.85.128.0/17 ... ~all
...
31 of 33 responding · 0 servfail · 1 unreachable · 1 answer group(s)
propagation (31/33 responding): v=spf1 ip4:74.125.0.0/16 ip4:209.85.128.0/17 ... ~all
```

### `cargo run -- example.com --once` (regression)

```
34 of 34 responding · 0 servfail · 0 unreachable · 2 answer group(s)
propagation (32/34 responding): 104.20.23.154, 172.66.147.243
```

### `cargo run -- 'a..b.example.com' --once TXT` (malformed name, up front)

One error, non-zero exit — instead of 34 identical ERR rows:

```
Error: invalid domain name "a..b.example.com": Malformed label:
exit=1
```

### ECS regression

`cargo run -- foo_bar.example.com --once TXT --ecs 203.0.113.0/24` still queries
(`0 of 11 responding · 6 unreachable · 17 no-ecs`) — unchanged behavior for a
nonexistent name, confirming the `Name`-instead-of-`&str` refactor didn't disturb
the raw ECS path.

### PTY session (TUI behavior)

Driven through a real PTY with `expect` at 30×110. After Enter on `a..b.com` the
header keeps the input and the gauge line reads:

```
not a domain name: Malformed label:
```

…with every table row still `— idle` — no ERR rows. After Ctrl+U and
`foo_bar.example.com` + Enter, the rows go through `⠋ query…` to `NONE No Error`
and the gauge reaches `propagation 0/33 · 1 unreachable · next poll in 29s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
