### PR TITLE
Stop one resolver's invented TTL from setting the TTL advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tenth of it), and any resolver that reported one is named on the note line
   with what it claims — that cache really will serve the old answer after a
   change, and it is worth knowing which one it is.
-  ([#XX](https://github.com/514-labs/dnsglobe/pull/XX))
+  ([#38](https://github.com/514-labs/dnsglobe/pull/38))
 
 ## [0.4.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   TUI — instead of filling the table with one identical error per resolver,
   which read like a network outage.
   ([#37](https://github.com/514-labs/dnsglobe/pull/37))
+- The TTL note no longer lets a single resolver speak for the zone. It used to
+  report the longest TTL any agreeing resolver returned, so one resolver
+  handing back an invented 8423s turned a 300s zone into "TTL ≈ 2h23m" and
+  advised lowering a TTL that was already low. The estimate now ignores
+  reports wildly out of line with the rest of the fleet (never more than a
+  tenth of it), and any resolver that reported one is named on the note line
+  with what it claims — that cache really will serve the old answer after a
+  change, and it is worth knowing which one it is.
+  ([#XX](https://github.com/514-labs/dnsglobe/pull/XX))
 
 ## [0.4.0] - 2026-07-11
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,12 @@ const HISTORY_CAP: usize = 32;
 /// record change (the "drop TTL to 30s a day before migrating" practice).
 pub const ADVISORY_TTL: u32 = 3600;
 
+/// How far above the fleet's 90th percentile a reported TTL has to sit before
+/// it stops counting as the same record's countdown. Honest countdowns for one
+/// record all live in `(0, configured_ttl]`, so a 4× gap can't come from
+/// caching timing — it's a resolver reporting a number of its own invention.
+const TTL_OUTLIER_FACTOR: u32 = 4;
+
 pub const RECORD_TYPES: &[RecordType] = &[
     RecordType::A,
     RecordType::AAAA,
@@ -129,6 +135,31 @@ struct Observation {
     values: Vec<String>,
     min_ttl: u32,
     at: Instant,
+}
+
+/// One resolver's reported TTL, attributable back to that resolver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TtlReport {
+    /// Index into `App::resolvers`, so callers can name the resolver.
+    pub index: usize,
+    /// The TTL it reported, in seconds.
+    pub ttl: u32,
+}
+
+/// What the fleet's reported TTLs say about the zone's configured TTL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TtlEstimate {
+    /// Best estimate of the zone's configured TTL, in seconds: the longest
+    /// countdown reported by a resolver whose number the rest of the fleet
+    /// corroborates.
+    pub ttl: u32,
+    /// How many majority rows reported a TTL at all (`ttl` plus `outliers`
+    /// were drawn from these).
+    pub samples: usize,
+    /// Reports too far above the fleet to be this record's countdown, longest
+    /// first. Not an error to surface and forget: such a cache keeps serving
+    /// the old answer well past the zone's stated lifetime.
+    pub outliers: Vec<TtlReport>,
 }
 
 /// Why a resolver is still serving a non-majority answer.
@@ -835,22 +866,69 @@ impl App {
         (now > deadline).then_some(TtlVerdict::PastTtl)
     }
 
-    /// Estimated configured TTL: the max reported TTL across majority rows.
-    /// A resolver that just refetched reports (nearly) the full configured
-    /// value, so the max over the fleet is within seconds of the zone's TTL.
-    pub fn estimated_ttl(&self, summary: &Summary) -> Option<u32> {
-        self.rows
+    /// Estimate the zone's configured TTL from what the majority rows report.
+    ///
+    /// A reported TTL is a *countdown*, not the configured value: a resolver
+    /// that just refetched reports (nearly) the full TTL, one halfway through
+    /// its cache entry reports half of it. So the longest report is the best
+    /// estimate — but only among resolvers reporting this record's countdown.
+    /// Some public resolvers hand back numbers unrelated to the authoritative
+    /// record (fixed floors, or values of their own invention), and taking a
+    /// plain max let one of them speak for the zone: a single resolver
+    /// reporting 8423s turned a 300s zone into "TTL ≈ 2h23m".
+    ///
+    /// So the max is taken over reports within `TTL_OUTLIER_FACTOR` of the
+    /// fleet's 90th percentile, and anything above that is returned separately
+    /// for the caller to attribute. Skipping a tenth of the fleet is what
+    /// bounds the damage: a handful of liars can't move the percentile, and by
+    /// construction no more than a tenth of the reports can be rejected. A
+    /// fleet where *most* resolvers fabricate the same long TTL is beyond what
+    /// resolver-side data can settle — dnsglobe never talks to the
+    /// authoritative servers, so there is no ground truth to fall back on.
+    pub fn estimated_ttl(&self, summary: &Summary) -> Option<TtlEstimate> {
+        let mut reports: Vec<TtlReport> = self
+            .rows
             .iter()
             .enumerate()
             .filter(|&(i, _)| summary.majority_rows[i])
-            .filter_map(|(_, row)| match row {
+            .filter_map(|(index, row)| match row {
                 RowState::Done {
                     result: QueryResult::Records { min_ttl, .. },
                     ..
-                } => Some(*min_ttl),
+                } => Some(TtlReport {
+                    index,
+                    ttl: *min_ttl,
+                }),
                 _ => None,
             })
-            .max()
+            .collect();
+        let samples = reports.len();
+        if samples == 0 {
+            return None;
+        }
+
+        reports.sort_unstable_by_key(|r| std::cmp::Reverse(r.ttl));
+        // Longest report left after skipping the top tenth. Under ten samples
+        // that tenth is empty and this is just the max, which is what we want:
+        // a percentile over a handful of resolvers is too thin to convict any
+        // of them of lying.
+        let bulk = reports[samples / 10].ttl;
+        let cutoff = bulk.saturating_mul(TTL_OUTLIER_FACTOR);
+        // A zero cutoff means most of the fleet is at the end of its countdown
+        // (or reports no TTL at all); every other report would then look like
+        // an outlier, so fall back to the plain max.
+        let outliers = if cutoff == 0 {
+            0
+        } else {
+            reports.iter().take_while(|r| r.ttl > cutoff).count()
+        };
+        Some(TtlEstimate {
+            // `bulk` is never above the cutoff, so a non-outlier always
+            // remains to speak for the zone.
+            ttl: reports[outliers].ttl,
+            samples,
+            outliers: reports[..outliers].to_vec(),
+        })
     }
 
     /// Worst-case wait until every non-majority cache must have refetched:
@@ -1437,11 +1515,15 @@ mod tests {
         assert_eq!(round.indices, vec![0, 2, 3]);
     }
 
-    #[test]
-    fn estimated_ttl_is_max_over_majority_rows_only() {
-        let mut app = app_with_answers(&[&["x"], &["x"], &["y"]]);
-        let ttls = [300u32, 3600, 999_999];
-        for (row, ttl) in app.rows.iter_mut().zip(ttls) {
+    /// One agreeing row per TTL, so every row lands in the majority.
+    fn app_agreeing_with_ttls(ttls: &[u32]) -> App {
+        let mut app = app_with_answers(&vec![&["x"] as &[&str]; ttls.len()]);
+        set_ttls(&mut app, ttls);
+        app
+    }
+
+    fn set_ttls(app: &mut App, ttls: &[u32]) {
+        for (row, &ttl) in app.rows.iter_mut().zip(ttls) {
             if let RowState::Done {
                 result: QueryResult::Records { min_ttl, .. },
                 ..
@@ -1450,9 +1532,111 @@ mod tests {
                 *min_ttl = ttl;
             }
         }
+    }
+
+    #[test]
+    fn estimated_ttl_is_max_over_majority_rows_only() {
+        let mut app = app_with_answers(&[&["x"], &["x"], &["y"]]);
+        set_ttls(&mut app, &[300, 3600, 999_999]);
         let summary = app.summary();
-        // The differing row's huge TTL must not leak into the estimate.
-        assert_eq!(app.estimated_ttl(&summary), Some(3600));
+        let est = app.estimated_ttl(&summary).unwrap();
+        // The differing row's huge TTL must not leak into the estimate, and
+        // under ten samples the longest agreeing report stands unchallenged.
+        assert_eq!(est.ttl, 3600);
+        assert_eq!(est.samples, 2);
+        assert!(est.outliers.is_empty());
+    }
+
+    #[test]
+    fn one_fabricated_ttl_does_not_set_the_estimate() {
+        // The reported case: 32 resolvers on a 300s zone, plus one reporting
+        // 8423s. The headline must stay with the zone, well under the
+        // advisory threshold, and the liar must be named instead.
+        let mut ttls = vec![124u32; 16];
+        ttls.extend([300u32; 15]);
+        ttls.push(430);
+        ttls.push(8423);
+        let app = app_agreeing_with_ttls(&ttls);
+        let summary = app.summary();
+        let est = app.estimated_ttl(&summary).unwrap();
+        assert_eq!(est.ttl, 430);
+        assert!(est.ttl < ADVISORY_TTL);
+        assert_eq!(est.samples, 33);
+        assert_eq!(
+            est.outliers,
+            vec![TtlReport {
+                index: 32,
+                ttl: 8423
+            }]
+        );
+    }
+
+    #[test]
+    fn a_genuinely_long_ttl_still_triggers_the_advisory() {
+        // A 1-day zone sampled mid-countdown: every report is a fraction of
+        // 86400, and the freshest ones sit at the full value. Nothing here is
+        // an outlier, and the estimate must clear ADVISORY_TTL.
+        let mut ttls: Vec<u32> = (0..32).map(|i| 86_400 - i * 2_500).collect();
+        ttls.push(86_400);
+        let app = app_agreeing_with_ttls(&ttls);
+        let summary = app.summary();
+        let est = app.estimated_ttl(&summary).unwrap();
+        assert_eq!(est.ttl, 86_400);
+        assert!(est.ttl >= ADVISORY_TTL);
+        assert!(est.outliers.is_empty());
+    }
+
+    #[test]
+    fn outlier_rejection_is_capped_at_a_tenth_of_the_fleet() {
+        // Five resolvers agreeing on a long TTL out of twenty are a fifth of
+        // the fleet: too many to dismiss as fabrications, so they set the
+        // estimate rather than being explained away.
+        let mut ttls = vec![300u32; 15];
+        ttls.extend([86_400u32; 5]);
+        let app = app_agreeing_with_ttls(&ttls);
+        let summary = app.summary();
+        let est = app.estimated_ttl(&summary).unwrap();
+        assert_eq!(est.ttl, 86_400);
+        assert!(est.outliers.is_empty());
+    }
+
+    #[test]
+    fn estimated_ttl_needs_a_majority_row_with_records() {
+        // Nothing queried yet.
+        let app = App::new("example.com".into());
+        assert_eq!(app.estimated_ttl(&app.summary()), None);
+
+        // Answered, but nothing that carries a TTL: no majority, no estimate.
+        let mut app = App::new("example.com".into());
+        app.rows = vec![
+            RowState::Done {
+                result: QueryResult::Error("timeout".into()),
+                elapsed: Duration::from_secs(3),
+                at: Instant::now(),
+                ecs_honored: None,
+            },
+            RowState::Done {
+                result: QueryResult::ServFail,
+                elapsed: Duration::from_millis(10),
+                at: Instant::now(),
+                ecs_honored: None,
+            },
+        ];
+        assert_eq!(app.estimated_ttl(&app.summary()), None);
+    }
+
+    #[test]
+    fn a_fleet_at_the_end_of_its_countdown_falls_back_to_the_max() {
+        // Reported TTLs are countdowns, so a fleet polled just before expiry
+        // reports zeros. Zero times anything is zero: without a fallback every
+        // non-zero report would look like an outlier.
+        let mut ttls = vec![0u32; 32];
+        ttls.push(300);
+        let app = app_agreeing_with_ttls(&ttls);
+        let summary = app.summary();
+        let est = app.estimated_ttl(&summary).unwrap();
+        assert_eq!(est.ttl, 300);
+        assert!(est.outliers.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -643,11 +643,27 @@ fn print_round(app: &App, summary: &app::Summary, multi: bool) {
         && summary.responding > 0
         && summary.agree == summary.responding
         && let Some(est) = app.estimated_ttl(summary)
-        && est >= app::ADVISORY_TTL
     {
-        println!(
-            "note: TTL ≈ {} — planning a record change? lower the TTL first, then wait one old-TTL period before switching.",
-            app::fmt_secs(u64::from(est))
-        );
+        if est.ttl >= app::ADVISORY_TTL {
+            println!(
+                "note: TTL ≈ {} — planning a record change? lower the TTL first, then wait one old-TTL period before switching.",
+                app::fmt_secs(u64::from(est.ttl))
+            );
+        }
+        // A resolver reporting far more than the fleet isn't counted in the
+        // estimate above, but it's worth naming: that cache serves the old
+        // answer for as long as it claims, whatever the zone says.
+        for outlier in &est.outliers {
+            let resolver = &app.resolvers[outlier.index];
+            println!(
+                "note: {} ({}) reports ttl={} where {} of {} resolvers report ttl<={} — that cache will serve the old answer long past the zone's TTL.",
+                resolver.name,
+                resolver.location,
+                outlier.ttl,
+                est.samples - est.outliers.len(),
+                est.samples,
+                est.ttl,
+            );
+        }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -27,13 +27,13 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // flagging outliers mid-flight makes rows flap as the majority shifts.
     let complete = summary.done > 0 && !app.in_flight();
 
-    let advisory = ttl_advisory(app, &summary, complete);
+    let note = ttl_note(app, &summary, complete);
     // The header grows one row for the ECS line, only when --ecs/config set
     // subnets up — an ECS-less run renders exactly as before.
     let [header, body, footer] = Layout::vertical([
         Constraint::Length(if app.ecs_list.is_empty() { 4 } else { 5 }),
         Constraint::Min(6),
-        Constraint::Length(if advisory.is_some() { 3 } else { 2 }),
+        Constraint::Length(if note.is_some() { 3 } else { 2 }),
     ])
     .areas(frame.area());
 
@@ -75,7 +75,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_map(frame, app, &summary, complete, &geom, map_area);
         draw_map_info(frame, app, &summary, complete, info_area);
     }
-    draw_footer(frame, app, &summary, advisory, footer);
+    draw_footer(frame, app, &summary, note, footer);
     if let Some(form) = &app.form {
         draw_resolver_form(frame, form, frame.area());
     }
@@ -99,20 +99,48 @@ fn info_rows(app: &App, summary: &Summary, complete: bool) -> u16 {
     }
 }
 
-/// One-line "lower your TTL before migrating" hint, shown once a round has
-/// settled with full agreement (the planning phase — mid-migration the advice
-/// comes too late) and the zone's TTL is long.
-fn ttl_advisory(app: &App, summary: &Summary, complete: bool) -> Option<String> {
+/// One-line TTL note, shown once a round has settled with full agreement (the
+/// planning phase — mid-migration the advice comes too late). It carries the
+/// "lower your TTL before migrating" hint when the zone's TTL is long, and
+/// names any resolver holding a far longer lease than the rest: with every
+/// resolver agreeing, that cache is the one thing left that can still serve
+/// the old answer after a change.
+fn ttl_note(app: &App, summary: &Summary, complete: bool) -> Option<String> {
     if !complete || summary.responding == 0 || summary.agree != summary.responding {
         return None;
     }
     let est = app.estimated_ttl(summary)?;
-    (est >= ADVISORY_TTL).then(|| {
-        format!(
+    let mut note = String::new();
+    if est.ttl >= ADVISORY_TTL {
+        note.push_str(&format!(
             "TTL ≈ {} — planning a record change? Lower the TTL first, then wait one old-TTL period before switching.",
-            fmt_secs(u64::from(est))
-        )
-    })
+            fmt_secs(u64::from(est.ttl))
+        ));
+    }
+    if let Some(worst) = est.outliers.first() {
+        if !note.is_empty() {
+            note.push_str(" · ");
+        } else {
+            note.push_str(&format!(
+                "TTL ≈ {} ({}/{} resolvers) · ",
+                fmt_secs(u64::from(est.ttl)),
+                est.samples - est.outliers.len(),
+                est.samples
+            ));
+        }
+        let resolver = &app.resolvers[worst.index];
+        note.push_str(&format!(
+            "{} ({}) reports {}{} — that cache will serve the old answer long past the zone's TTL.",
+            resolver.name,
+            resolver.location,
+            fmt_secs(u64::from(worst.ttl)),
+            match est.outliers.len() {
+                1 => String::new(),
+                n => format!(" (+{} more)", n - 1),
+            }
+        ));
+    }
+    (!note.is_empty()).then_some(note)
 }
 
 fn draw_header(frame: &mut Frame, app: &App, area: Rect) {
@@ -662,13 +690,7 @@ fn draw_map_info(frame: &mut Frame, app: &App, summary: &Summary, complete: bool
     );
 }
 
-fn draw_footer(
-    frame: &mut Frame,
-    app: &App,
-    summary: &Summary,
-    advisory: Option<String>,
-    area: Rect,
-) {
+fn draw_footer(frame: &mut Frame, app: &App, summary: &Summary, note: Option<String>, area: Rect) {
     let th = theme::active();
     let mut status = Line::default();
     if let Some((domain, rtype, ecs)) = &app.queried {
@@ -729,18 +751,18 @@ fn draw_footer(
         ),
         th.muted.style(),
     ));
-    if let Some(advisory) = advisory {
-        let advisory_line = Line::from(vec![
+    if let Some(note) = note {
+        let note_line = Line::from(vec![
             Span::styled(" ℹ ", Style::new().fg(th.accent)),
-            Span::styled(advisory, th.muted.style().italic()),
+            Span::styled(note, th.muted.style().italic()),
         ]);
-        let [advisory_area, status_area, keys_area] = Layout::vertical([
+        let [note_area, status_area, keys_area] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Length(1),
         ])
         .areas(area);
-        frame.render_widget(Paragraph::new(advisory_line), advisory_area);
+        frame.render_widget(Paragraph::new(note_line), note_area);
         frame.render_widget(Paragraph::new(status), status_area);
         frame.render_widget(Paragraph::new(keys), keys_area);
     } else {
@@ -835,5 +857,46 @@ mod tests {
         // …capped so a many-valued record doesn't crush the globe.
         summary.majority_values = vec!["v".into(); 30];
         assert_eq!(info_rows(&app, &summary, true), 26);
+    }
+
+    /// Every resolver agreeing on one answer, each with its own reported TTL.
+    fn settled_app(ttls: &[u32]) -> App {
+        let mut app = App::new("example.com".into());
+        app.rows = ttls
+            .iter()
+            .map(|&min_ttl| RowState::Done {
+                result: QueryResult::Records {
+                    values: vec!["192.0.2.1".into()],
+                    min_ttl,
+                },
+                elapsed: std::time::Duration::from_millis(10),
+                at: Instant::now(),
+                ecs_honored: None,
+            })
+            .collect();
+        app
+    }
+
+    #[test]
+    fn ttl_note_attributes_an_outlier_rather_than_headlining_it() {
+        let n = App::new(String::new()).resolvers.len();
+        let mut ttls = vec![300u32; n - 1];
+        ttls.push(8423);
+        let app = settled_app(&ttls);
+        let note = ttl_note(&app, &app.summary(), true).unwrap();
+        // The zone's TTL leads; the lone long report is named, not obeyed.
+        assert!(note.starts_with("TTL ≈ 5m00s"), "{note}");
+        assert!(note.contains(&app.resolvers[n - 1].name), "{note}");
+        assert!(note.contains("2h20m"), "{note}");
+        assert!(!note.contains("Lower the TTL first"), "{note}");
+
+        // Nothing to say about a short TTL the whole fleet agrees on.
+        let app = settled_app(&vec![300u32; n]);
+        assert_eq!(ttl_note(&app, &app.summary(), true), None);
+
+        // A genuinely long TTL still gets the planning advice.
+        let app = settled_app(&vec![86_400u32; n]);
+        let note = ttl_note(&app, &app.summary(), true).unwrap();
+        assert!(note.starts_with("TTL ≈ 1d0h — planning"), "{note}");
     }
 }


### PR DESCRIPTION
Fixes #35.

**The bug.** `estimated_ttl` took the max reported TTL across majority rows, so one resolver reporting a fabricated 8423s made a 300s zone read `TTL ≈ 2h23m — lower the TTL first`. 32 of 33 resolvers reported ≤430.

**Why max stays the estimator.** A reported TTL is a countdown, not the configured value: only the resolver that just refetched reports (nearly) the zone's TTL. A median or plain percentile would report roughly half the real TTL — wrong in the other direction. What was missing was a bound on *who gets to be* the max.

**The bound.** Sort majority-row reports descending, take `bulk = reports[samples / 10]` (the longest report after skipping the top tenth ≈ the 90th percentile), reject anything above `4 × bulk`. Two properties: a few liars cannot move the percentile, and **at most a tenth of the fleet can ever be rejected** — if 20% of resolvers agree on a long TTL, they set the headline. Below ten samples `samples / 10 == 0`, so `bulk` is the max and nothing is rejected: small/custom resolver lists behave exactly as before. A zero cutoff (fleet at the end of its countdown) falls back to the plain max.

"Prefer the authoritative TTL" was not pursued: dnsglobe never queries authoritative servers, so there is no ground truth available — noted in the doc comment as the limit of what resolver-side data can settle.

**Outliers are surfaced, not hidden.** `estimated_ttl` now returns `TtlEstimate { ttl, samples, outliers: Vec<TtlReport> }` carrying resolver indices; `ui.rs`'s `ttl_advisory` became `ttl_note` and renders either/both of the planning advice and the attributed outlier, and `--once` prints a matching note. Logic stayed in `app.rs`, formatting in `ui.rs`/`main.rs`.

**Verification.** `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (103 passed, +7 tests) all clean.

Live e2e, `cargo run -- 514.ax --once TXT` — the reported resolver reproduced (Comss.one RU returned `ttl=8571`, everyone else 300, Baidu 402):

before (main):
```
note: TTL ≈ 2h21m — planning a record change? lower the TTL first, then wait one old-TTL period before switching.
```
after:
```
note: Comss.one (RU) reports ttl=8571 where 32 of 33 resolvers report ttl<=402 — that cache will serve the old answer long past the zone's TTL.
```

TUI verified through a PTY (`expect`, 200×40, `dnsglobe 514.ax TXT`), footer note line:
```
ℹ TTL ≈ 6m12s (32/33 resolvers) · Comss.one (RU) reports 2h21m — that cache will serve the old answer long past the zone's TTL.
```

Smoke test `cargo run -- example.com --once`: 34/34 responding, 2 answer groups → no note (`agree != responding`), as before.

**Demo GIF.** `demo/demo.tape` records against 514.ax, which currently trips the new outlier note, so the README GIF will show a footer line it doesn't have today — worth a re-record in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
