### PR TITLE
Discover anycast sites via NSID, falling back to id.server probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Anycast site discovery now asks every resolver for its NSID (RFC 5001)
+  first — a standard EDNS option servers answer with their own node name —
+  and only falls back to the old operator-specific `id.server` probes when
+  that names no place. More resolvers report where they actually answered
+  from: Lumen shows `→JFK`, CIRA Canadian Shield `→YYZ`, DNS4EU `→AMS` and
+  DNS.SB `→KIX` where they used to show only the operator's home region.
+  Resolvers you add yourself in the config file can now report a site too,
+  since NSID needs no per-operator support, and Google's site takes one
+  query instead of two. Nothing that already resolved to a site changed.
+  ([#36](https://github.com/514-labs/dnsglobe/issues/36),
+  [#39](https://github.com/514-labs/dnsglobe/pull/39))
+
 ### Fixed
 
 - Names with an underscore in the middle of a label are queried instead of

--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ globe, which needs fewer columns; resizing across the threshold morphs one
 into the other. Ctrl+O toggles map/globe by hand, and `--view auto|map|globe`
 (or `view = "..."` in the config file) forces a style outright.
 
-Anycast networks are asked which of their sites is answering you: Quad9
-(`TXT id.server.on.quad9.net`), Cloudflare (`CH TXT id.server`), Google
-(egress subnet via `TXT o-o.myaddr.l.google.com` matched against
-`TXT locations.publicdns.goog`), OpenDNS (`TXT debug.opendns.com`),
-CleanBrowsing, and Neustar UltraDNS. The discovered site shows in the Loc
-column as `→YUL`-style codes, and the resolver's map dot moves to the POP
-actually serving your queries.
+Every resolver is asked which of its sites is answering you, via NSID
+(RFC 5001) — an EDNS option the answering node fills with its own name
+(`gpdns-yul`, `yul01`, `res721.qyul1`, `jfk-dns1-02.inet.centurylink.net`).
+It needs no per-operator support, so resolvers you add yourself can report a
+site too. Where NSID names no place, the operator-specific identification
+queries take over: Quad9 (`TXT id.server.on.quad9.net`), Cloudflare
+(`CH TXT id.server`), Google (egress subnet via
+`TXT o-o.myaddr.l.google.com` matched against `TXT locations.publicdns.goog`),
+OpenDNS (`TXT debug.opendns.com`), CleanBrowsing, and Neustar UltraDNS. The
+discovered site shows in the Loc column as `→YUL`-style codes, and the
+resolver's map dot moves to the POP actually serving your queries.
 
 ## Usage
 
@@ -155,9 +159,9 @@ startup with the offending entry named.
 ## Notes
 
 - Several resolvers are anycast networks, so the responding node is the one
-  nearest to you. Networks with an identification query report the actual
-  answering site (`→YUL`); for the rest the location column is the
-  operator's home region.
+  nearest to you. Networks that identify their node — via NSID or an
+  identification query — report the actual answering site (`→YUL`); for the
+  rest the location column is the operator's home region.
 - The built-in resolver list lives in `src/resolvers.rs`; use the config file
   above to extend or replace it without rebuilding. Every built-in entry was
   verified to answer external queries; many well-known ISP resolvers (and,

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -7,7 +7,7 @@ use hickory_resolver::config::{NameServerConfig, ResolveHosts, ResolverConfig};
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::net::{DnsError, NetError};
 use hickory_resolver::proto::op::{Edns, Message, Query, ResponseCode};
-use hickory_resolver::proto::rr::rdata::opt::{EdnsCode, EdnsOption};
+use hickory_resolver::proto::rr::rdata::opt::{EdnsCode, EdnsOption, NSIDPayload};
 use hickory_resolver::proto::rr::{DNSClass, Name, RData, RecordType};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -358,6 +358,55 @@ async fn exchange_tcp(server: IpAddr, request: &[u8], id: u16) -> Option<Message
     (response.metadata.id == id).then_some(response)
 }
 
+/// NSID request (RFC 5001): an EDNS option we send *empty* — that empty form
+/// is the request — which the server answers by echoing the option filled
+/// with its own identity string. It rides an ordinary query, so any server
+/// that implements it identifies itself without needing `id.server` support.
+///
+/// The carrier query is `. NS`: every recursive resolver has the root NS set
+/// cached, so it is the cheapest thing to ask, and it keeps the probe from
+/// leaking the domain the user is watching.
+fn nsid_message() -> Message {
+    let mut message = Message::query();
+    message.metadata.recursion_desired = true;
+    message.add_query(Query::query(Name::root(), RecordType::NS));
+    let mut edns = Edns::new();
+    edns.set_max_payload(EDNS_PAYLOAD);
+    edns.options_mut().insert(EdnsOption::NSID(
+        NSIDPayload::new(Vec::new()).expect("an empty NSID payload always fits"),
+    ));
+    message.edns = Some(edns);
+    message
+}
+
+/// RFC 5001 leaves the payload opaque, but operators put a printable ASCII
+/// host/site name in it. Anything else is hex-encoded (what `dig +nsid`
+/// shows) rather than dropped or mangled through lossy UTF-8, which could
+/// invent letters that never crossed the wire. An empty payload — some
+/// servers echo the option back unfilled — identifies nothing, so it is None.
+fn decode_nsid(payload: &[u8]) -> Option<String> {
+    let text = if payload.iter().all(|b| (0x20..=0x7e).contains(b)) {
+        String::from_utf8(payload.to_vec()).ok()?.trim().to_string()
+    } else {
+        payload.iter().map(|b| format!("{b:02x}")).collect()
+    };
+    (!text.is_empty()).then_some(text)
+}
+
+/// Ask a server to identify itself via NSID. None means it does not support
+/// the option (or did not answer) — the caller falls back to an `id.server`
+/// probe, and failing that the resolver keeps its configured location.
+pub async fn nsid(server: IpAddr) -> Option<String> {
+    let message = nsid_message();
+    let response = exchange(server, &message).await.ok()?;
+    match response.edns.as_ref()?.option(EdnsCode::NSID)? {
+        EdnsOption::NSID(payload) => decode_nsid(payload.as_ref()),
+        // A server that echoes code 3 with something hickory could not parse
+        // as an NSID payload is not identifying itself in any usable way.
+        _ => None,
+    }
+}
+
 /// IN TXT query returning each TXT character-string separately (a record's
 /// strings are answers like `"prefix code"` entries — joining them would
 /// destroy the structure). Used by the anycast site probes; None on any
@@ -561,6 +610,32 @@ mod tests {
             edns.option(EdnsCode::Subnet),
             Some(&EdnsOption::Subnet(subnet))
         );
+    }
+
+    #[test]
+    fn nsid_message_requests_an_empty_option() {
+        let message = nsid_message();
+        // RFC 5001 §2.1: the requester sends the option with zero-length data.
+        let edns = message.edns.as_ref().unwrap();
+        match edns.option(EdnsCode::NSID).unwrap() {
+            EdnsOption::NSID(payload) => assert!(payload.as_ref().is_empty()),
+            other => panic!("expected an NSID option, got {other:?}"),
+        }
+        let query = &message.queries[0];
+        assert!(query.name().is_root());
+        assert_eq!(query.query_type(), RecordType::NS);
+    }
+
+    #[test]
+    fn nsid_payloads_decode_as_ascii_or_hex() {
+        assert_eq!(decode_nsid(b"gpdns-yul").as_deref(), Some("gpdns-yul"));
+        // Trailing whitespace/NULs some servers pad with carry no meaning.
+        assert_eq!(decode_nsid(b"  yul01 ").as_deref(), Some("yul01"));
+        // Non-ASCII stays verifiable as hex instead of becoming U+FFFD.
+        assert_eq!(decode_nsid(&[0xc0, 0xff, 0xee]).as_deref(), Some("c0ffee"));
+        // An echoed-but-unfilled option identifies nothing.
+        assert_eq!(decode_nsid(b""), None);
+        assert_eq!(decode_nsid(b"   "), None);
     }
 
     /// A response as classify sees it: flip the id-generated query into a

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,13 +430,13 @@ fn poll_query(app: &mut App, tx: &mpsc::UnboundedSender<QueryOutcome>) {
     spawn_round(app, tx, round);
 }
 
-/// Ask each anycast resolver which of its sites is answering us (issue #6).
-/// One shot per run: the site follows our network path, not the query.
+/// Ask each resolver which of its sites is answering us (issues #6 and #36).
+/// One shot per run: the site follows our network path, not the query. Every
+/// resolver is asked — NSID needs no per-operator support, so even one the
+/// user added themselves can identify its node.
 fn spawn_site_probes(app: &App, site_tx: &mpsc::UnboundedSender<(IpAddr, sites::Site)>) {
     for resolver in &app.resolvers {
-        let Some(probe) = resolver.probe else {
-            continue;
-        };
+        let probe = resolver.probe;
         let site_tx = site_tx.clone();
         let server = resolver.ip;
         tokio::spawn(async move {
@@ -480,10 +480,8 @@ async fn run_once(domain: String, rtype: RecordType, ecs_list: Vec<ClientSubnet>
     // Site probes run concurrently with the first query round.
     let mut probes = tokio::task::JoinSet::new();
     for (index, resolver) in app.resolvers.iter().enumerate() {
-        if let Some(probe) = resolver.probe {
-            let server = resolver.ip;
-            probes.spawn(async move { (index, sites::discover(probe, server).await) });
-        }
+        let (probe, server) = (resolver.probe, resolver.ip);
+        probes.spawn(async move { (index, sites::discover(probe, server).await) });
     }
 
     let selections: Vec<Option<usize>> = if app.ecs_list.is_empty() {

--- a/src/sites.rs
+++ b/src/sites.rs
@@ -1,10 +1,19 @@
 //! Anycast site discovery: ask a resolver *which* of its sites answered.
 //!
-//! Large anycast networks expose an identification query — Quad9 answers
-//! `TXT id.server.on.quad9.net`, Cloudflare answers `CH TXT id.server`,
-//! Google reports its egress subnet, OpenDNS has `TXT debug.opendns.com`.
-//! The answer names the POP (usually by IATA airport code), telling you
-//! where your queries actually land instead of the operator's home region.
+//! The general answer is NSID (RFC 5001): an EDNS option every query can
+//! carry, which the answering node fills with its own identity string —
+//! `gpdns-yul` (Google), `yul01` (Cloudflare), `res721.qyul1` (Quad9),
+//! `jfk-dns1-02.inet.centurylink.net` (Lumen). One option on one query, no
+//! per-operator special casing, and it works on servers that never
+//! implemented an identification *query*. See
+//! <https://github.com/514-labs/dnsglobe/issues/36>.
+//!
+//! Where NSID names no recognizable place, the operator-specific probes stay
+//! as the fallback — Quad9 answers `TXT id.server.on.quad9.net`, Cloudflare
+//! answers `CH TXT id.server`, Google reports its egress subnet, OpenDNS has
+//! `TXT debug.opendns.com`. Either way the answer names the POP (usually by
+//! IATA airport code), telling you where your queries actually land instead
+//! of the operator's home region.
 //! See <https://github.com/514-labs/dnsglobe/issues/6>.
 
 use std::net::IpAddr;
@@ -48,10 +57,25 @@ impl Site {
     }
 }
 
-/// Run one resolver's identification query. None means the probe failed or
-/// the answer was unparseable — the resolver keeps its configured location.
-pub async fn discover(probe: SiteProbe, server: IpAddr) -> Option<Site> {
-    match probe {
+/// Identify the answering node. NSID goes first — it costs one query, needs
+/// no operator-specific support, and is the only thing we can ask a resolver
+/// the user added themselves (those carry no `probe`). When it names no
+/// place we fall back to the operator's identification query, and when that
+/// fails too the resolver keeps its configured location.
+pub async fn discover(probe: Option<SiteProbe>, server: IpAddr) -> Option<Site> {
+    if let Some(id) = dns::nsid(server).await {
+        if let Some(site) = parse_nsid(&id) {
+            return Some(site);
+        }
+        // Operators with a free-form site name publish the same string over
+        // NSID as over `id.server`, so asking again would only repeat it.
+        if probe == Some(SiteProbe::ChIdServer)
+            && let Some(site) = parse_freeform(std::slice::from_ref(&id))
+        {
+            return Some(site);
+        }
+    }
+    match probe? {
         SiteProbe::Quad9 => {
             let strings = dns::txt_strings(server, "id.server.on.quad9.net").await?;
             parse_quad9(&strings)
@@ -74,6 +98,38 @@ pub async fn discover(probe: SiteProbe, server: IpAddr) -> Option<Site> {
             parse_freeform(&strings)
         }
     }
+}
+
+/// Pull the POP out of an NSID string. Operators encode it as one label of
+/// an otherwise free-form host name — `gpdns-yul`, `yul01`, `res721.qyul1`,
+/// `r2005.yyz`, `CS-YYZ3`, `dns4eu-ams-01`, `jp-kix-5` — so scan the labels
+/// left to right and take the first that is a known airport.
+///
+/// Requiring a *known* airport is the point: plenty of NSID strings are pure
+/// infrastructure (`pdns-recursor-58b7c5d77d-bjzkj`, `tserv21`, `230@dns9`),
+/// and inventing a location from those would be worse than showing the
+/// operator's configured region.
+fn parse_nsid(id: &str) -> Option<Site> {
+    id.split(|c: char| !c.is_ascii_alphanumeric())
+        .find_map(iata_in_label)
+        .map(|code| Site::from_code(&code))
+}
+
+/// A known airport code inside one NSID label, if any. Node numbering is
+/// suffixed (`yul01`, `yyz3`), and Quad9 prefixes its POPs with `q`
+/// (`qyul1`), so both forms reduce to a bare three-letter code.
+fn iata_in_label(label: &str) -> Option<String> {
+    let stem = label.trim_end_matches(|c: char| c.is_ascii_digit());
+    if !stem.chars().all(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    let code = match stem.len() {
+        3 => stem,
+        4 if stem.starts_with(['q', 'Q']) => &stem[1..],
+        _ => return None,
+    }
+    .to_ascii_uppercase();
+    airport_coords(&code).is_some().then_some(code)
 }
 
 /// `res120.qyul1.on.quad9.net` → the label starting with `q` names the POP:
@@ -466,6 +522,43 @@ mod tests {
             assert!(code.chars().all(|c| c.is_ascii_uppercase()));
             assert!((-90.0..=90.0).contains(&lat), "{code} lat");
             assert!((-180.0..=180.0).contains(&lon), "{code} lon");
+        }
+    }
+
+    /// Every string here was captured off the wire with `dig +nsid`.
+    #[test]
+    fn real_nsid_strings_yield_their_pop() {
+        for (id, code) in [
+            ("gpdns-yul", "YUL"),                        // Google
+            ("yul01", "YUL"),                            // Cloudflare
+            ("res721.qyul1", "YUL"),                     // Quad9
+            ("r2005.yyz", "YYZ"),                        // OpenDNS
+            ("jfk-dns1-02.inet.centurylink.net", "JFK"), // Lumen
+            ("CS-YYZ3", "YYZ"),                          // CIRA Canadian Shield
+            ("dns4eu-ams-01", "AMS"),                    // DNS4EU
+            ("jp-kix-5", "KIX"),                         // DNS.SB
+        ] {
+            let site = parse_nsid(id).unwrap_or_else(|| panic!("{id} yielded no site"));
+            assert_eq!(site.code, code, "from {id}");
+            assert!(site.coords.is_some(), "{code} should be on the map");
+        }
+    }
+
+    /// NSID strings that name no place must stay silent rather than promote
+    /// a hostname fragment to a location.
+    #[test]
+    fn nsid_without_a_known_airport_is_none() {
+        for id in [
+            "pdns-recursor-58b7c5d77d-bjzkj", // FortiGuard
+            "tserv21",                        // Hurricane Electric
+            "230@dns9",                       // CZ.NIC ODVR
+            "ny2-hw-edge-gc7.fe.gc.onl",      // Gcore
+            "us-dns-rh1s",
+            "pad", // Telstra: not an airport we map
+            "",
+            "c0ffee", // a hex-encoded binary payload
+        ] {
+            assert!(parse_nsid(id).is_none(), "{id} should name no site");
         }
     }
 


### PR DESCRIPTION
Fixes #36.

## What changed

Anycast site discovery now asks every resolver for its NSID (RFC 5001) first — a standard EDNS option the answering node fills with its own identity string — and only falls back to the operator-specific `id.server`-style probes when NSID names no recognizable place. Servers that support neither keep behaving exactly as today.

## How it works

**Requesting NSID** (`src/dns.rs`): a new `pub async fn nsid(server) -> Option<String>` reuses the existing raw-message machinery (`Edns` + `exchange()`, the same path ECS uses). The carrier query is `. NS` with an *empty* `EdnsOption::NSID` — hickory-proto 0.26.1 has a native `EdnsOption::NSID(NSIDPayload)` / `EdnsCode::NSID`, so no new dependencies and no hand-rolled `Unknown(3, …)`. Root NS is the carrier because every recursive resolver has it cached, and it keeps the probe from leaking the domain the user is watching. `decode_nsid` keeps the byte→string rule pure: printable ASCII as-is (trimmed), anything else hex-encoded (like `dig +nsid`), empty → `None`.

The main query path deliberately stays on hickory's resolver (with its retry/TCP handling) rather than moving to raw messages just to carry NSID — the site is session-static, so it rides the existing one-shot probe.

**Extracting the site** (`src/sites.rs`): `parse_nsid` splits the NSID string on non-alphanumerics and takes the first label that resolves to a **known** airport in the existing `AIRPORTS` table. `iata_in_label` strips node-number suffixes (`yul01`, `CS-YYZ3` → `yyz3`) and handles Quad9's `q<iata><n>` form (`qyul1` → `yul`). Requiring a table hit is the key safety property: strings like `pdns-recursor-58b7c5d77d-bjzkj`, `tserv21`, `230@dns9` yield nothing rather than a fabricated location.

**Fallback**: `discover` now takes `Option<SiteProbe>`. NSID runs first; if it names no airport, the resolver's original probe runs unchanged. For `ChIdServer` resolvers the NSID string *is* the `id.server` string, so it is fed straight to `parse_freeform`, saving a query. `main.rs` no longer skips `probe: None` resolvers — every resolver gets probed, so resolvers added in the config file can now report a site too.

## Tests

- `dns::nsid_message_requests_an_empty_option` — RFC 5001 §2.1 shape
- `dns::nsid_payloads_decode_as_ascii_or_hex` — ASCII, padding, binary→hex, empty
- `sites::real_nsid_strings_yield_their_pop` — 8 strings captured off the wire with `dig +nsid` (Google `gpdns-yul`, Cloudflare `yul01`, Quad9 `res721.qyul1`, OpenDNS `r2005.yyz`, Lumen `jfk-dns1-02.inet.centurylink.net`, CIRA `CS-YYZ3`, DNS4EU `dns4eu-ams-01`, DNS.SB `jp-kix-5`)
- `sites::nsid_without_a_known_airport_is_none` — 8 real no-place strings stay silent

## Verification

Quality gates (what CI runs):

```
cargo fmt --check                         → clean
cargo clippy --all-targets -- -D warnings → clean
cargo test                                → 101 passed; 0 failed
```

`cargo run -- example.com --once`, main vs this branch (live, same network path):

| Resolver | main | this branch |
|---|---|---|
| Lumen (Qwest) | `US` | **`→JFK`** |
| CIRA Canadian Shield | `CA` | **`→YYZ`** |
| DNS4EU | `EU/Any` | **`→AMS`** |
| DNS.SB | `DE/Any` | **`→KIX`** |
| Google / Cloudflare / Quad9 | `→YUL` | `→YUL` |
| OpenDNS | `→YYZ` | `→YYZ` |
| CleanBrowsing | `→NEWYORK` | `→NEWYORK` |
| Neustar UltraDNS | `→USNYC` | `→USNYC` |
| all others | unchanged | unchanged |

Strictly additive: four new site codes, zero regressions.

TUI verified through a PTY (`expect`, 45×150, per the AGENTS.md gotchas) — rendered frames contain `→AMS`, `→JFK`, `→KIX`, `→NEWYORK`, `→USNYC`, `→YUL`, `→YYZ`, so the new sites reach both the Loc column and the map dots.

Config-only resolver list (`replace = true`, entries with no built-in probe, previously never probed):

```
Custom (via 1.1.1.1)    →YUL   1.1.1.1       OK   8ms
Custom (via Lumen)      →JFK   205.171.3.66  OK  17ms
```

**Demo GIF**: the only visual delta is more `→XXX` codes in the Loc column — worth a fresh `vhs` run at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
