### PR TITLE
Correct docs and the sort label ahead of the next release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,15 @@ human contributor.
 | File | Owns |
 |---|---|
 | `src/main.rs` | CLI (clap), event loop, key handling, `--once` mode |
-| `src/app.rs` | `App` state, input editing, answer grouping, TTL verdicts |
+| `src/app.rs` | `App` state, input editing, answer grouping, TTL verdicts, table column layout |
 | `src/ui.rs` | All rendering: map, table, gauge, footer |
+| `src/theme.rs` | UI color roles, `Paint`/`Muted` parsing |
+| `src/globe.rs` | Orthographic globe projection and panel geometry |
+| `src/world_data.rs` | Coastline vector data |
 | `src/dns.rs` | Resolver queries and error mapping |
 | `src/resolvers.rs` | Built-in resolver list |
-| `src/config.rs` | TOML config file (custom resolvers) |
-| `src/sites.rs` | Anycast POP discovery (id.server probes, IATA codes) |
+| `src/config.rs` | TOML config file (resolvers, theme, ecs, view) |
+| `src/sites.rs` | Anycast POP discovery (NSID, id.server fallback, IATA codes) |
 
 Keep logic in `app.rs` (testable, no I/O) and rendering in `ui.rs`. Key
 bindings live in `handle_key` in `main.rs` and should call one-line `App`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (Ping, TTL, Exp) are right-aligned so their digits line up, units that the
   header already implies are gone, and where there isn't room for the
   spelled-out status the verdict moves to a glyph in the left margin
-  (`✓ ≠ ! ↻ ∅ ✗`) — one place to scan for failures. Wider terminals are
-  unchanged: they keep the status word, the same answer column and the same
-  map/globe thresholds.
+  (`✓ ≠ ! ↻ ∅ ✗`) — one place to scan for failures. The round-trip column is
+  now headed `Ping` (it was `Time`). Wider terminals are unchanged: they keep
+  the status word, the same answer column and the same map/globe thresholds.
+  `--once` matches: it prints the same name/location/IP column widths as the
+  TUI and right-aligns its TTL, so the two views line up.
   ([#33](https://github.com/514-labs/dnsglobe/issues/33),
   [#40](https://github.com/514-labs/dnsglobe/pull/40))
 - The per-row expiry countdown is coarse: at most two digits and a unit
@@ -25,7 +27,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   precise figure (`TTL ≈ 2h23m`).
   ([#33](https://github.com/514-labs/dnsglobe/issues/33),
   [#40](https://github.com/514-labs/dnsglobe/pull/40))
-- Failures now show as a white-on-red badge on the status glyph and word
+- Failures now show as a white-on-red badge — on the status glyph and word in
+  the table, and on the `not a domain name` label under a malformed input —
   rather than red text, which went washed-out on terminal themes with a
   mid-toned background (macOS Terminal's "Ocean"). Only the marker is
   filled — error messages, map dots, the propagation gauge and slow ping
@@ -72,7 +75,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tenth of it), and any resolver that reported one is named on the note line
   with what it claims — that cache really will serve the old answer after a
   change, and it is worth knowing which one it is.
-  ([#38](https://github.com/514-labs/dnsglobe/pull/38))
+  ([#35](https://github.com/514-labs/dnsglobe/issues/35),
+  [#38](https://github.com/514-labs/dnsglobe/pull/38))
 
 ## [0.4.0] - 2026-07-11
 
@@ -110,7 +114,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   toggles by hand and pins the choice; `--view auto|map|globe` or `view =
   "..."` in the config file force it outright (flag beats config).
   ([#26](https://github.com/514-labs/dnsglobe/pull/26))
-
 - Nix flake support: `nix run github:514-labs/dnsglobe` builds and runs
   dnsglobe from source on any system with Nix flakes enabled; specific
   releases can be pinned via git tag (`github:514-labs/dnsglobe/v0.3.0`).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ their own location, not the probed network.
 | ↑/↓ / PgUp/PgDn | move the highlight through the resolver table (scrolls to follow) |
 | +              | add a resolver for this session (name, IP, optional location and map position) |
 | Ctrl+X         | remove the highlighted resolver for this session |
-| Ctrl+S         | cycle table sort: resolver / location / time / status / answer |
+| Ctrl+S         | cycle table sort: resolver / location / ping / status / answer |
 | Ctrl+O         | toggle the world view between flat map and rotating globe |
 | Ctrl+N         | cycle the ECS client subnet and re-query (only when `--ecs`/config set one up) |
 | Ctrl+U         | clear domain                    |
@@ -187,7 +187,7 @@ The project provides optional Nix flake outputs for users who already use Nix. T
 nix run github:514-labs/dnsglobe
 
 # Specific release (uses the flake at that git tag)
-nix run github:514-labs/dnsglobe/v0.3.1
+nix run github:514-labs/dnsglobe/v0.4.0
 
 # Named outputs (if the flake exposes them): #latest, #source
 nix run github:514-labs/dnsglobe#source

--- a/src/app.rs
+++ b/src/app.rs
@@ -79,7 +79,7 @@ impl SortMode {
         match self {
             SortMode::Resolver => "resolver",
             SortMode::Location => "location",
-            SortMode::Time => "time",
+            SortMode::Time => "ping",
             SortMode::Status => "status",
             SortMode::Answer => "answer",
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,8 @@ Configuration:
   # stale = \"208\"        #   stale, upstream, muted, coastline, grid
   # muted = \"faint\"      # colors: ANSI names (\"lightred\"), 256-color
   #                      #   indexes (\"208\"), or hex (\"#ff8700\"); `muted`
-  #                      #   also takes \"faint\" (dim the default foreground)";
+  #                      #   also takes \"faint\" (dim the default foreground)
+  # error = \"white on lightred\"  # \"<fg> on <bg>\" badges the failure marker";
 
 /// Global DNS propagation checker TUI — watch a DNS record propagate across
 /// public resolvers worldwide, on a world map in your terminal.


### PR DESCRIPTION
Pre-release docs and consistency cleanup, from a QA + documentation audit of main ahead of cutting 0.5.0. No behavior changes except one user-visible label.

## What changed

**CHANGELOG.md**
- The TTL-outlier entry now links issue #35 alongside PR #38, matching every sibling entry's style.
- The 80-column entry now mentions the `Time` → `Ping` header rename and that `--once` prints the same name/location/IP widths and right-aligns its TTL — both shipped in #40 but were undocumented, and the `--once` format is documented as script-consumable.
- The error-badge entry now names the third badged element (the `not a domain name` label), not just the status glyph and word.
- Removed a stray blank line inside 0.4.0's `Added` section (formatting only).

**README.md**
- Nix pin example bumped `v0.3.1` → `v0.4.0` (newest existing tag).
- Ctrl+S sort list says `ping` instead of `time`, matching the label change below.

**src/app.rs** — `SortMode::label` returns `"ping"` instead of `"time"`, so the footer's `sort: …` agrees with the column header #40 renamed. Covered by the amended #40 changelog entry per the AGENTS.md amendment rule (behavior introduced in `[Unreleased]`).

**src/main.rs** — the long `--help`'s `[theme]` block documents the `"<fg> on <bg>"` badge form added in #40:
```
# error = "white on lightred"  # "<fg> on <bg>" badges the failure marker
```

**AGENTS.md** — module map brought up to date: `sites.rs` is NSID-first with `id.server` as fallback (#39); added the missing `theme.rs`, `globe.rs`, and `world_data.rs` rows; `config.rs` owns theme/ecs/view as well as resolvers; `app.rs` also owns the table column layout (#40's `TableLayout`).

## Verification

```
cargo fmt --check                         → clean
cargo clippy --all-targets -- -D warnings → clean
cargo test                                → 120 passed; 0 failed
```

`cargo run -- example.com --once` smoke-tested. PTY run of the real binary confirms the footer now cycles `sort: resolver → location → ping → status → answer`, agreeing with the README table and the `Ping` column header. `--help` shows the new theme line at the width of the surrounding block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
