### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-07
+
 ### Changed
 
 - The resolver table now fits an 80-column terminal without cropping

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "dnsglobe"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dnsglobe"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Global DNS propagation checker TUI — watch a DNS record propagate across 34 public resolvers worldwide, on a world map in your terminal"


### PR DESCRIPTION
Version-bump PR per the AGENTS.md release process:

- `Cargo.toml` version 0.4.0 → 0.5.0 (`Cargo.lock` refreshed via `cargo check`)
- `CHANGELOG.md`: `[Unreleased]` renamed to `[0.5.0] - 2026-08-07`, fresh empty `[Unreleased]` added above

0.5.0 ships the four merged changes: mid-label underscore support (#37, fixes #34), outlier-resistant TTL advisory (#38, fixes #35), NSID-based anycast site discovery (#39, fixes #36), and the 80-column/error-badge/coarse-countdown TUI redesign (#40, fixes #33), plus the docs cleanup (#41).

Minor (not patch) because the release includes new config syntax (`"<fg> on <bg>"`), a changed default error rendering, changed Loc values from NSID, and a changed `--once` column format — no breaking changes (old configs verified to parse).

On merge, `tag-release.yml` will dispatch `release.yml` to build binaries, publish to crates.io and the Homebrew tap, and create the `v0.5.0` tag and GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)